### PR TITLE
fix(download): preserve unique paths for duplicate basenames

### DIFF
--- a/cmd/cernopendata-client/integration_test.go
+++ b/cmd/cernopendata-client/integration_test.go
@@ -5,6 +5,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"hash/adler32"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -612,6 +616,10 @@ func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
 
+func adlerChecksum(content []byte) string {
+	return fmt.Sprintf("adler32:%08x", adler32.Checksum(content))
+}
+
 func TestIntegrationDownloadFilesFromRecid(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -633,6 +641,97 @@ func TestIntegrationDownloadFilesFromRecid(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(tmpDir, "0d0714743f0204ed3c0144941e6ce248.configFile.py")); os.IsNotExist(err) {
 		t.Error("Expected file to be downloaded")
+	}
+}
+
+func TestIntegrationDownloadFilesDuplicateBasenamesWithLocalServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	const recid = 11537
+
+	fileA := []byte("content from 0002")
+	fileB := []byte("content from 0003")
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case fmt.Sprintf("/api/records/%d", recid):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": fmt.Sprintf("%d", recid),
+				"metadata": map[string]any{
+					"recid": recid,
+					"_file_indices": []any{
+						map[string]any{
+							"key":  "index-1",
+							"size": len(fileA) + len(fileB),
+							"files": []any{
+								map[string]any{
+									"uri":      server.URL + "/files/0002/AO2D.root",
+									"size":     len(fileA),
+									"checksum": adlerChecksum(fileA),
+								},
+								map[string]any{
+									"uri":      server.URL + "/files/0003/AO2D.root",
+									"size":     len(fileB),
+									"checksum": adlerChecksum(fileB),
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/files/0002/AO2D.root":
+			_, _ = w.Write(fileA)
+		case "/files/0003/AO2D.root":
+			_, _ = w.Write(fileB)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+
+	// #nosec G204
+	cmd := exec.Command(
+		getBinaryPath(),
+		"download-files",
+		"--recid", fmt.Sprintf("%d", recid),
+		"--server", server.URL,
+		"--output-dir", tmpDir,
+		"--verify",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("download-files against local server failed: %v\nOutput: %s", err, string(output))
+	}
+
+	for relPath, want := range map[string]string{
+		"0002/AO2D.root": string(fileA),
+		"0003/AO2D.root": string(fileB),
+	} {
+		// #nosec G304 -- relPath is constrained to fixed test cases in this table
+		got, readErr := os.ReadFile(filepath.Join(tmpDir, relPath))
+		if readErr != nil {
+			t.Fatalf("failed to read downloaded file %s: %v", relPath, readErr)
+		}
+		if string(got) != want {
+			t.Errorf("downloaded content for %s = %q, want %q", relPath, string(got), want)
+		}
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "Verified: 0002/AO2D.root") {
+		t.Errorf("expected verification output for 0002/AO2D.root, got:\n%s", outputStr)
+	}
+	if !contains(outputStr, "Verified: 0003/AO2D.root") {
+		t.Errorf("expected verification output for 0003/AO2D.root, got:\n%s", outputStr)
+	}
+	if !contains(outputStr, "Success") {
+		t.Errorf("expected success output, got:\n%s", outputStr)
 	}
 }
 

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -180,6 +180,7 @@ func (d *Downloader) DownloadFiles(files []any, baseDir string, retry int, retry
 	d.verbose = verbose
 	d.dryRun = dryRun
 	d.showProgress = showProgress
+	AssignLocalPaths(files)
 
 	stats := DownloadStats{}
 	stats.TotalFiles = len(files)
@@ -200,19 +201,20 @@ func (d *Downloader) DownloadFiles(files []any, baseDir string, retry int, retry
 		uri, _ := fileMap["uri"].(string)
 		size, _ := fileMap["size"].(float64)
 		checksum, _ := fileMap["checksum"].(string)
+		displayPath := DisplayPath(fileMap)
 
 		stats.TotalBytes += int64(size)
 
-		printer.DisplayMessage(printer.Info, fmt.Sprintf("Downloading file %d/%d: %s", i+1, stats.TotalFiles, filepath.Base(uri)))
+		printer.DisplayMessage(printer.Info, fmt.Sprintf("Downloading file %d/%d: %s", i+1, stats.TotalFiles, displayPath))
 
 		if dryRun {
-			printer.DisplayMessage(printer.Note, fmt.Sprintf("Would download: %s (size: %d, checksum: %s)", uri, int64(size), checksum))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("Would download: %s -> %s (size: %d, checksum: %s)", uri, displayPath, int64(size), checksum))
 			stats.DownloadedFiles++
 			stats.DownloadedBytes += int64(size)
 			continue
 		}
 
-		destPath := filepath.Join(baseDir, filepath.Base(uri))
+		destPath := DestinationPath(baseDir, fileMap)
 
 		if fi, err := os.Stat(destPath); err == nil {
 			if fi.Size() >= int64(size) {

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -488,6 +488,84 @@ func TestDownloadFiles(t *testing.T) {
 	}
 }
 
+func TestAssignLocalPathsUsesMinimalUniqueSuffix(t *testing.T) {
+	files := []any{
+		map[string]any{"uri": "http://opendata.cern.ch//eos/opendata/alice/2015/LHC15o/000245349/0002/AO2D.root"},
+		map[string]any{"uri": "http://opendata.cern.ch//eos/opendata/alice/2015/LHC15o/000245349/0003/AO2D.root"},
+		map[string]any{"uri": "http://opendata.cern.ch//eos/opendata/alice/2015/LHC15o/000245349/0004/AO2D.root"},
+	}
+
+	AssignLocalPaths(files)
+
+	expected := []string{"0002/AO2D.root", "0003/AO2D.root", "0004/AO2D.root"}
+	for i, file := range files {
+		fileMap := file.(map[string]any)
+		localPath, _ := fileMap["local_path"].(string)
+		if localPath != expected[i] {
+			t.Errorf("local_path[%d] = %q, want %q", i, localPath, expected[i])
+		}
+	}
+}
+
+func TestAssignLocalPathsExtendsSuffixUntilUnique(t *testing.T) {
+	files := []any{
+		map[string]any{"uri": "http://example.com/store/runA/0001/AO2D.root"},
+		map[string]any{"uri": "http://example.com/store/runB/0001/AO2D.root"},
+	}
+
+	AssignLocalPaths(files)
+
+	expected := []string{"runA/0001/AO2D.root", "runB/0001/AO2D.root"}
+	for i, file := range files {
+		fileMap := file.(map[string]any)
+		localPath, _ := fileMap["local_path"].(string)
+		if localPath != expected[i] {
+			t.Errorf("local_path[%d] = %q, want %q", i, localPath, expected[i])
+		}
+	}
+}
+
+func TestDownloadFilesPreservesUniqueSubdirectoriesForDuplicateBasenames(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("file content"))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	files := []any{
+		map[string]any{
+			"uri":      server.URL + "/dataset/0002/AO2D.root",
+			"size":     float64(12),
+			"checksum": "adler32:12345678",
+		},
+		map[string]any{
+			"uri":      server.URL + "/dataset/0003/AO2D.root",
+			"size":     float64(12),
+			"checksum": "adler32:87654321",
+		},
+	}
+
+	tmpDir := t.TempDir()
+	d := &Downloader{
+		client:     server.Client(),
+		retryLimit: 1,
+		retrySleep: 0,
+	}
+
+	stats := d.DownloadFiles(files, tmpDir, 1, 0, false, false, false)
+	if stats.DownloadedFiles != 2 {
+		t.Fatalf("DownloadedFiles = %d, want 2", stats.DownloadedFiles)
+	}
+
+	for _, relPath := range []string{"0002/AO2D.root", "0003/AO2D.root"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, relPath)); err != nil {
+			t.Errorf("expected downloaded file at %s: %v", relPath, err)
+		}
+	}
+}
+
 func TestDownloadFilesDryRun(t *testing.T) {
 	downloadCount := 0
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/internal/downloader/paths.go
+++ b/internal/downloader/paths.go
@@ -1,0 +1,211 @@
+package downloader
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type filePathInfo struct {
+	fileMap  map[string]any
+	baseName string
+	segments []string
+}
+
+// AssignLocalPaths computes a collision-free relative destination for each file.
+// When multiple URIs share the same basename, it preserves the shortest unique
+// trailing directory suffix needed to distinguish them.
+func AssignLocalPaths(files []any) {
+	groups := make(map[string][]filePathInfo)
+
+	for _, file := range files {
+		fileMap, ok := file.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if localPath, ok := fileMap["local_path"].(string); ok && sanitizeLocalPath(localPath) != "" {
+			fileMap["local_path"] = sanitizeLocalPath(localPath)
+			continue
+		}
+
+		uri, _ := fileMap["uri"].(string)
+		segments := uriPathSegments(uri)
+		if len(segments) == 0 {
+			baseName := filepath.Base(uri)
+			if baseName == "." || baseName == string(filepath.Separator) || baseName == "" {
+				baseName = "downloaded-file"
+			}
+			fileMap["local_path"] = baseName
+			continue
+		}
+
+		baseName := segments[len(segments)-1]
+		groups[baseName] = append(groups[baseName], filePathInfo{
+			fileMap:  fileMap,
+			baseName: baseName,
+			segments: segments,
+		})
+	}
+
+	for _, group := range groups {
+		if len(group) == 1 {
+			group[0].fileMap["local_path"] = group[0].baseName
+			continue
+		}
+
+		assignGroupLocalPaths(group)
+	}
+}
+
+func DestinationPath(baseDir string, fileMap map[string]any) string {
+	return filepath.Join(baseDir, getLocalPath(fileMap))
+}
+
+func DisplayPath(fileMap map[string]any) string {
+	localPath := getLocalPath(fileMap)
+	if localPath != "" {
+		return filepath.ToSlash(localPath)
+	}
+
+	uri, _ := fileMap["uri"].(string)
+	return filepath.Base(uri)
+}
+
+func getLocalPath(fileMap map[string]any) string {
+	if fileMap == nil {
+		return ""
+	}
+
+	if localPath, ok := fileMap["local_path"].(string); ok {
+		return sanitizeLocalPath(localPath)
+	}
+
+	uri, _ := fileMap["uri"].(string)
+	segments := uriPathSegments(uri)
+	if len(segments) == 0 {
+		return ""
+	}
+
+	return segments[len(segments)-1]
+}
+
+func assignGroupLocalPaths(group []filePathInfo) {
+	resolved := make([]string, len(group))
+	unresolved := make(map[int]struct{}, len(group))
+	maxDepth := 0
+
+	for i, item := range group {
+		unresolved[i] = struct{}{}
+		if len(item.segments) > maxDepth {
+			maxDepth = len(item.segments)
+		}
+	}
+
+	for depth := 2; depth <= maxDepth; depth++ {
+		candidates := make(map[string][]int)
+		for idx := range unresolved {
+			candidate := suffixPath(group[idx].segments, depth)
+			candidates[candidate] = append(candidates[candidate], idx)
+		}
+
+		for candidate, indices := range candidates {
+			if len(indices) != 1 {
+				continue
+			}
+			idx := indices[0]
+			resolved[idx] = candidate
+			delete(unresolved, idx)
+		}
+
+		if len(unresolved) == 0 {
+			break
+		}
+	}
+
+	for idx := range unresolved {
+		resolved[idx] = strings.Join(group[idx].segments, "/")
+	}
+
+	seen := make(map[string]struct{})
+	for i, candidate := range resolved {
+		candidate = sanitizeLocalPath(candidate)
+		if candidate == "" {
+			candidate = group[i].baseName
+		}
+
+		uniqueCandidate := candidate
+		for suffix := 2; ; suffix++ {
+			if _, exists := seen[uniqueCandidate]; !exists {
+				break
+			}
+			uniqueCandidate = addNumericSuffix(candidate, suffix)
+		}
+
+		seen[uniqueCandidate] = struct{}{}
+		group[i].fileMap["local_path"] = uniqueCandidate
+	}
+}
+
+func suffixPath(segments []string, depth int) string {
+	if len(segments) == 0 {
+		return ""
+	}
+	if depth > len(segments) {
+		depth = len(segments)
+	}
+	return strings.Join(segments[len(segments)-depth:], "/")
+}
+
+func addNumericSuffix(localPath string, n int) string {
+	ext := path.Ext(localPath)
+	base := strings.TrimSuffix(localPath, ext)
+	return fmt.Sprintf("%s-%d%s", base, n, ext)
+}
+
+func uriPathSegments(uri string) []string {
+	cleaned := strings.TrimSpace(uri)
+	if cleaned == "" {
+		return nil
+	}
+
+	if parsed, err := url.Parse(cleaned); err == nil && parsed.Path != "" {
+		cleaned = parsed.Path
+	}
+
+	cleaned = path.Clean(cleaned)
+	if cleaned == "." || cleaned == "/" {
+		return nil
+	}
+
+	rawSegments := strings.Split(strings.TrimPrefix(cleaned, "/"), "/")
+	segments := make([]string, 0, len(rawSegments))
+	for _, segment := range rawSegments {
+		if segment == "" || segment == "." || segment == ".." {
+			continue
+		}
+		segments = append(segments, segment)
+	}
+
+	return segments
+}
+
+func sanitizeLocalPath(localPath string) string {
+	cleaned := path.Clean(strings.TrimSpace(localPath))
+	if cleaned == "." || cleaned == "/" || cleaned == "" {
+		return ""
+	}
+
+	rawSegments := strings.Split(strings.TrimPrefix(cleaned, "/"), "/")
+	segments := make([]string, 0, len(rawSegments))
+	for _, segment := range rawSegments {
+		if segment == "" || segment == "." || segment == ".." {
+			continue
+		}
+		segments = append(segments, segment)
+	}
+
+	return strings.Join(segments, "/")
+}

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/clelange/cernopendata-client-go/internal/checksum"
+	"github.com/clelange/cernopendata-client-go/internal/downloader"
 	"github.com/clelange/cernopendata-client-go/internal/printer"
 )
 
@@ -77,6 +78,7 @@ func (v *Verifier) VerifyLocalFiles(directory string) (*VerificationStats, error
 func (v *Verifier) VerifyFiles(directory string, expectedFiles []any) (*VerificationStats, error) {
 	stats := &VerificationStats{}
 	stats.TotalFiles = len(expectedFiles)
+	downloader.AssignLocalPaths(expectedFiles)
 
 	for _, file := range expectedFiles {
 		fileMap, ok := file.(map[string]any)
@@ -85,12 +87,10 @@ func (v *Verifier) VerifyFiles(directory string, expectedFiles []any) (*Verifica
 			continue
 		}
 
-		uri, _ := fileMap["uri"].(string)
 		expectedSize, _ := fileMap["size"].(float64)
 		expectedChecksum, _ := fileMap["checksum"].(string)
-
-		fileName := filepath.Base(uri)
-		filePath := filepath.Join(directory, fileName)
+		displayPath := downloader.DisplayPath(fileMap)
+		filePath := downloader.DestinationPath(directory, fileMap)
 
 		result := VerificationResult{
 			Path:         filePath,
@@ -128,18 +128,18 @@ func (v *Verifier) VerifyFiles(directory string, expectedFiles []any) (*Verifica
 		if !result.SizeMatch {
 			stats.SizeFailed++
 			printer.DisplayMessage(printer.Error, fmt.Sprintf("Size mismatch: %s (expected: %d, actual: %d)",
-				fileName, result.ExpectedSize, result.ActualSize))
+				displayPath, result.ExpectedSize, result.ActualSize))
 		}
 
 		if !result.ChecksumMatch {
 			stats.ChecksumFailed++
 			printer.DisplayMessage(printer.Error, fmt.Sprintf("Checksum mismatch: %s (expected: %s, actual: %s)",
-				fileName, result.ExpectedSum, result.ActualSum))
+				displayPath, result.ExpectedSum, result.ActualSum))
 		}
 
 		if result.SizeMatch && result.ChecksumMatch {
 			stats.VerifiedFiles++
-			printer.DisplayMessage(printer.Info, fmt.Sprintf("Verified: %s", fileName))
+			printer.DisplayMessage(printer.Info, fmt.Sprintf("Verified: %s", displayPath))
 		}
 	}
 

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -45,7 +45,7 @@ func TestVerifyFiles(t *testing.T) {
 		map[string]any{
 			"uri":      "http://example.com/test.txt",
 			"size":     float64(len(content)),
-			"checksum": "adler32:08879620",
+			"checksum": "adler32:1f2904dc",
 		},
 	}
 
@@ -61,6 +61,48 @@ func TestVerifyFiles(t *testing.T) {
 
 	if stats.MissingFiles != 0 {
 		t.Errorf("Expected 0 missing files, got %d", stats.MissingFiles)
+	}
+}
+
+func TestVerifyFilesUsesAssignedLocalPath(t *testing.T) {
+	testDir := t.TempDir()
+	for _, dir := range []string{"0002", "0003"} {
+		if err := os.MkdirAll(filepath.Join(testDir, dir), 0750); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	content := []byte("test content")
+	for _, filePath := range []string{
+		filepath.Join(testDir, "0002", "AO2D.root"),
+		filepath.Join(testDir, "0003", "AO2D.root"),
+	} {
+		if err := os.WriteFile(filePath, content, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	verifier := NewVerifier()
+	expectedFiles := []any{
+		map[string]any{
+			"uri":      "http://example.com/run/0002/AO2D.root",
+			"size":     float64(len(content)),
+			"checksum": "adler32:1f2904dc",
+		},
+		map[string]any{
+			"uri":      "http://example.com/run/0003/AO2D.root",
+			"size":     float64(len(content)),
+			"checksum": "adler32:1f2904dc",
+		},
+	}
+
+	stats, err := verifier.VerifyFiles(testDir, expectedFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stats.VerifiedFiles != 2 {
+		t.Errorf("Expected 2 verified files, got %d", stats.VerifiedFiles)
 	}
 }
 

--- a/internal/xrootddownloader/downloader.go
+++ b/internal/xrootddownloader/downloader.go
@@ -14,6 +14,7 @@ import (
 	"go-hep.org/x/hep/xrootd/xrdio"
 
 	"github.com/clelange/cernopendata-client-go/internal/config"
+	"github.com/clelange/cernopendata-client-go/internal/downloader"
 	"github.com/clelange/cernopendata-client-go/internal/printer"
 	"github.com/clelange/cernopendata-client-go/internal/utils"
 )
@@ -278,6 +279,7 @@ func (d *Downloader) DownloadFiles(ctx context.Context, files []any, baseDir str
 	d.verbose = verbose
 	d.dryRun = dryRun
 	d.showProgress = showProgress
+	downloader.AssignLocalPaths(files)
 
 	stats := DownloadStats{}
 	stats.TotalFiles = len(files)
@@ -298,19 +300,20 @@ func (d *Downloader) DownloadFiles(ctx context.Context, files []any, baseDir str
 		uri, _ := fileMap["uri"].(string)
 		size, _ := fileMap["size"].(float64)
 		checksum, _ := fileMap["checksum"].(string)
+		displayPath := downloader.DisplayPath(fileMap)
 
 		stats.TotalBytes += int64(size)
 
-		printer.DisplayMessage(printer.Info, fmt.Sprintf("Downloading file %d/%d: %s", i+1, stats.TotalFiles, filepath.Base(uri)))
+		printer.DisplayMessage(printer.Info, fmt.Sprintf("Downloading file %d/%d: %s", i+1, stats.TotalFiles, displayPath))
 
 		if dryRun {
-			printer.DisplayMessage(printer.Note, fmt.Sprintf("Would download: %s (size: %d, checksum: %s)", uri, int64(size), checksum))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("Would download: %s -> %s (size: %d, checksum: %s)", uri, displayPath, int64(size), checksum))
 			stats.DownloadedFiles++
 			stats.DownloadedBytes += int64(size)
 			continue
 		}
 
-		destPath := filepath.Join(baseDir, filepath.Base(uri))
+		destPath := downloader.DestinationPath(baseDir, fileMap)
 
 		if fi, err := os.Stat(destPath); err == nil {
 			if fi.Size() >= int64(size) {


### PR DESCRIPTION
Assign a deterministic local path to each downloaded file so datasets with repeated basenames do not overwrite earlier downloads.

When basename collisions are detected, preserve the shortest unique trailing directory suffix and reuse the same path during verification.

Refs: cernopendata/cernopendata-client#177