### PR TITLE
fix: guard search pagination progress

### DIFF
--- a/cmd/cernopendata-client/search.go
+++ b/cmd/cernopendata-client/search.go
@@ -58,7 +58,7 @@ Examples:
 
 		// Handle --list-facets
 		if listFacets {
-			facets, err := client.GetFacets()
+			facets, err := client.GetFacetsContext(cmd.Context())
 			if err != nil {
 				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to fetch facets: %v", err))
 				os.Exit(1)
@@ -125,9 +125,9 @@ Examples:
 
 		// Handle --size -1 for fetching all results
 		if size == -1 {
-			searchResp, err = client.SearchAllRecords(queryPattern, facetsMap, sort)
+			searchResp, err = client.SearchAllRecordsContext(cmd.Context(), queryPattern, facetsMap, sort)
 		} else {
-			searchResp, err = client.SearchRecords(queryPattern, facetsMap, page, size, sort)
+			searchResp, err = client.SearchRecordsContext(cmd.Context(), queryPattern, facetsMap, page, size, sort)
 		}
 
 		if err != nil {

--- a/internal/searcher/searcher.go
+++ b/internal/searcher/searcher.go
@@ -1,6 +1,7 @@
 package searcher
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -437,6 +438,12 @@ func GetRecid(server, doi string, title string, recid int) (int, error) {
 // page and size control pagination, sort controls ordering.
 // Returns records with metadata included.
 func (c *Client) SearchRecords(q string, facets map[string]string, page, size int, sort string) (*SearchResponse, error) {
+	return c.SearchRecordsContext(context.Background(), q, facets, page, size, sort)
+}
+
+// SearchRecordsContext searches for records using a query string and optional facets.
+// The request is canceled when ctx is done.
+func (c *Client) SearchRecordsContext(ctx context.Context, q string, facets map[string]string, page, size int, sort string) (*SearchResponse, error) {
 	params := url.Values{}
 	if q != "" {
 		params.Set("q", q)
@@ -453,7 +460,12 @@ func (c *Client) SearchRecords(q string, facets map[string]string, page, size in
 
 	searchURL := fmt.Sprintf("%s/api/records/?%s", c.server, params.Encode())
 
-	resp, err := c.client.Get(searchURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create search request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search records: %w", err)
 	}
@@ -474,13 +486,19 @@ func (c *Client) SearchRecords(q string, facets map[string]string, page, size in
 // SearchAllRecords fetches all matching records by paginating through results
 // in batches of 50. Returns a combined SearchResponse with all hits.
 func (c *Client) SearchAllRecords(q string, facets map[string]string, sort string) (*SearchResponse, error) {
+	return c.SearchAllRecordsContext(context.Background(), q, facets, sort)
+}
+
+// SearchAllRecordsContext fetches all matching records while honoring ctx.
+func (c *Client) SearchAllRecordsContext(ctx context.Context, q string, facets map[string]string, sort string) (*SearchResponse, error) {
 	const batchSize = 50
 	var allHits []SearchHit
+	seenIDs := make(map[string]struct{})
 	page := 1
 	totalRecords := 0
 
 	for {
-		resp, err := c.SearchRecords(q, facets, page, batchSize, sort)
+		resp, err := c.SearchRecordsContext(ctx, q, facets, page, batchSize, sort)
 		if err != nil {
 			return nil, err
 		}
@@ -489,7 +507,33 @@ func (c *Client) SearchAllRecords(q string, facets map[string]string, sort strin
 			totalRecords = resp.Hits.Total
 		}
 
-		allHits = append(allHits, resp.Hits.Hits...)
+		if totalRecords == 0 {
+			break
+		}
+
+		if len(resp.Hits.Hits) == 0 {
+			return nil, fmt.Errorf(
+				"search pagination made no progress on page %d: received an empty page after %d of %d records",
+				page, len(allHits), totalRecords,
+			)
+		}
+
+		newHits := 0
+		for _, hit := range resp.Hits.Hits {
+			if _, seen := seenIDs[hit.ID]; seen {
+				continue
+			}
+			seenIDs[hit.ID] = struct{}{}
+			allHits = append(allHits, hit)
+			newHits++
+		}
+
+		if newHits == 0 {
+			return nil, fmt.Errorf(
+				"search pagination made no progress on page %d: received no new records after %d of %d records",
+				page, len(allHits), totalRecords,
+			)
+		}
 
 		// Check if we've fetched all records
 		if len(allHits) >= totalRecords {
@@ -510,8 +554,13 @@ func (c *Client) SearchAllRecords(q string, facets map[string]string, sort strin
 // GetFacets fetches available facets (aggregations) from the API.
 // This makes a minimal search request to get the aggregation data.
 func (c *Client) GetFacets() (map[string]Aggregation, error) {
+	return c.GetFacetsContext(context.Background())
+}
+
+// GetFacetsContext fetches available facets while honoring ctx.
+func (c *Client) GetFacetsContext(ctx context.Context) (map[string]Aggregation, error) {
 	// Make a minimal search to get aggregations
-	resp, err := c.SearchRecords("", nil, 1, 1, "")
+	resp, err := c.SearchRecordsContext(ctx, "", nil, 1, 1, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/searcher/searcher_test.go
+++ b/internal/searcher/searcher_test.go
@@ -1,7 +1,10 @@
 package searcher
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -657,7 +660,7 @@ func TestSearchRecords(t *testing.T) {
 			defer server.Close()
 
 			client := NewClient(server.URL)
-			resp, err := client.SearchRecords(tt.q, tt.facets, tt.page, tt.size, tt.sort)
+			resp, err := client.SearchRecordsContext(context.Background(), tt.q, tt.facets, tt.page, tt.size, tt.sort)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SearchRecords() error = %v, wantErr %v", err, tt.wantErr)
@@ -744,7 +747,7 @@ func TestGetFacets(t *testing.T) {
 			defer server.Close()
 
 			client := NewClient(server.URL)
-			facets, err := client.GetFacets()
+			facets, err := client.GetFacetsContext(context.Background())
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetFacets() error = %v, wantErr %v", err, tt.wantErr)
@@ -795,7 +798,7 @@ func TestSearchRecordsWithAggregations(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	resp, err := client.SearchRecords("test", nil, 1, 10, "")
+	resp, err := client.SearchRecordsContext(context.Background(), "test", nil, 1, 10, "")
 
 	if err != nil {
 		t.Fatalf("SearchRecords() error = %v", err)
@@ -886,7 +889,7 @@ func TestSearchAllRecords(t *testing.T) {
 			defer server.Close()
 
 			client := NewClient(server.URL)
-			resp, err := client.SearchAllRecords("test", nil, "")
+			resp, err := client.SearchAllRecordsContext(context.Background(), "test", nil, "")
 
 			if err != nil {
 				t.Fatalf("SearchAllRecords() error = %v", err)
@@ -932,10 +935,147 @@ func TestSearchAllRecordsError(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	_, err := client.SearchAllRecords("test", nil, "")
+	_, err := client.SearchAllRecordsContext(context.Background(), "test", nil, "")
 
 	if err == nil {
-		t.Error("SearchAllRecords() expected error on second page, got nil")
+		t.Fatal("SearchAllRecords() expected error on second page, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Fatalf("SearchAllRecords() error = %v, want HTTP status diagnostic", err)
+	}
+}
+
+func TestSearchAllRecordsRejectsPaginationWithoutProgress(t *testing.T) {
+	tests := []struct {
+		name          string
+		secondPage    []SearchHit
+		wantErrorText string
+	}{
+		{
+			name:          "empty page",
+			secondPage:    []SearchHit{},
+			wantErrorText: "received an empty page after 1 of 2 records",
+		},
+		{
+			name:          "repeated page",
+			secondPage:    []SearchHit{{ID: "1"}},
+			wantErrorText: "received no new records after 1 of 2 records",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				page := r.URL.Query().Get("page")
+				hits := []SearchHit{{ID: "1"}}
+				if page == "2" {
+					hits = tt.secondPage
+				}
+				_ = json.NewEncoder(w).Encode(SearchResponse{
+					Hits: SearchHits{Total: 2, Hits: hits},
+				})
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL)
+			_, err := client.SearchAllRecordsContext(context.Background(), "test", nil, "")
+			if err == nil {
+				t.Fatal("SearchAllRecordsContext() error = nil, want pagination progress error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrorText) {
+				t.Fatalf("SearchAllRecordsContext() error = %q, want text %q", err, tt.wantErrorText)
+			}
+			if requests != 2 {
+				t.Fatalf("SearchAllRecordsContext() requests = %d, want 2", requests)
+			}
+		})
+	}
+}
+
+func TestSearchAllRecordsPreservesOrderWhileDeduplicating(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages := map[string][]SearchHit{
+			"1": {
+				{ID: "2", Metadata: map[string]any{"title": "second"}},
+				{ID: "1", Metadata: map[string]any{"title": "first"}},
+			},
+			"2": {
+				{ID: "1", Metadata: map[string]any{"title": "duplicate"}},
+				{ID: "3", Metadata: map[string]any{"title": "third"}},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(SearchResponse{
+			Hits: SearchHits{Total: 3, Hits: pages[r.URL.Query().Get("page")]},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	resp, err := client.SearchAllRecordsContext(context.Background(), "test", nil, "")
+	if err != nil {
+		t.Fatalf("SearchAllRecordsContext() error = %v", err)
+	}
+
+	gotIDs := make([]string, 0, len(resp.Hits.Hits))
+	for _, hit := range resp.Hits.Hits {
+		gotIDs = append(gotIDs, hit.ID)
+	}
+	if got, want := fmt.Sprint(gotIDs), "[2 1 3]"; got != want {
+		t.Fatalf("SearchAllRecordsContext() IDs = %s, want %s", got, want)
+	}
+}
+
+func TestSearchRequestsRespectCancellation(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context, *Client) error
+	}{
+		{
+			name: "record search",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.SearchRecordsContext(ctx, "test", nil, 1, 10, "")
+				return err
+			},
+		},
+		{
+			name: "fetch all",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.SearchAllRecordsContext(ctx, "test", nil, "")
+				return err
+			},
+		},
+		{
+			name: "facets",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.GetFacetsContext(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlerCalled := make(chan struct{}, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled <- struct{}{}
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := tt.call(ctx, NewClient(server.URL))
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("request error = %v, want context.Canceled", err)
+			}
+			select {
+			case <-handlerCalled:
+				t.Fatal("canceled request reached the HTTP handler")
+			default:
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- add context-aware search, fetch-all, and facets requests with compatibility wrappers
- preserve first-seen record order while deduplicating repeated IDs
- stop with explicit errors when advertised pagination returns an empty or no-progress page

## Validation

- deterministic multipage, zero-result, HTTP-error, empty-page, repeated-page, partial-duplicate, ordering, and cancellation fixtures
- go test, vet, race, cross-platform builds, goimports, golangci-lint, gosec, pre-commit, and diff checks