### PR TITLE
refactor: return command errors through cobra

### DIFF
--- a/cmd/cernopendata-client/download_files.go
+++ b/cmd/cernopendata-client/download_files.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cernopendata/cernopendata-client-go/internal/config"
 	"github.com/cernopendata/cernopendata-client-go/internal/downloader"
+	"github.com/cernopendata/cernopendata-client-go/internal/filemetadata"
 	"github.com/cernopendata/cernopendata-client-go/internal/printer"
 	"github.com/cernopendata/cernopendata-client-go/internal/searcher"
 	"github.com/cernopendata/cernopendata-client-go/internal/utils"
@@ -16,10 +17,24 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/xrootddownloader"
 )
 
-var downloadFilesCmd = &cobra.Command{
-	Use:   "download-files",
-	Short: "Download files from a record",
-	Long: `Download data files belonging to a record.
+type xrootdFileDownloader interface {
+	DownloadFiles(context.Context, []filemetadata.File, string, int, int, bool, bool, bool) downloader.DownloadStats
+	Close() error
+}
+
+type xrootdDownloaderFactory func() xrootdFileDownloader
+
+func newDownloadFilesCommand() *cobra.Command {
+	return newDownloadFilesCommandWithXRootD(func() xrootdFileDownloader {
+		return xrootddownloader.NewDownloader()
+	})
+}
+
+func newDownloadFilesCommandWithXRootD(newXRootDDownloader xrootdDownloaderFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download-files",
+		Short: "Download files from a record",
+		Long: `Download data files belonging to a record.
 
 Select a CERN Open Data bibliographic record by a record ID, a
 DOI, or a title and download data files belonging to this record.
@@ -35,211 +50,201 @@ Examples:
      $ cernopendata-client download-files --recid 5500 --filter-range 1-4
 
      $ cernopendata-client download-files --recid 5500 --filter-range 1-2,5-7`,
-	Run: func(cmd *cobra.Command, args []string) {
-		recid, err := cmd.Flags().GetInt("recid")
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid recid: %v", err))
-			os.Exit(1)
-		}
-		doi, _ := cmd.Flags().GetString("doi")
-		title, _ := cmd.Flags().GetString("title")
-		outputDir, _ := cmd.Flags().GetString("output-dir")
-		filterName, _ := cmd.Flags().GetString("filter-name")
-		filterRegexp, _ := cmd.Flags().GetString("filter-regexp")
-		filterRange, _ := cmd.Flags().GetString("filter-range")
-		expand, _ := cmd.Flags().GetBool("expand")
-		noExpand, _ := cmd.Flags().GetBool("no-expand")
-		retryLimit, _ := cmd.Flags().GetInt("retry-limit")
-		retrySleep, _ := cmd.Flags().GetInt("retry-sleep")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		verifyFlag, _ := cmd.Flags().GetBool("verify")
-		downloadEngine, _ := cmd.Flags().GetString("download-engine")
-		protocol, _ := cmd.Flags().GetString("protocol")
-		server, _ := cmd.Flags().GetString("server")
-		fileAvailability, _ := cmd.Flags().GetString("file-availability")
-
-		if fileAvailability != "" && fileAvailability != "online" && fileAvailability != "all" {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid file availability: %s (choose from 'online', 'all')", fileAvailability))
-			os.Exit(1)
-		}
-
-		if cmd.Flags().Changed("expand") && cmd.Flags().Changed("no-expand") {
-			printer.DisplayMessage(printer.Error, "Cannot specify both --expand and --no-expand")
-			os.Exit(1)
-		}
-
-		if noExpand {
-			expand = false
-		}
-
-		if server == "" {
-			server = config.ServerHTTPURI
-		}
-
-		parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to find record: %v", err))
-			os.Exit(1)
-		}
-
-		if outputDir == "" {
-			outputDir = fmt.Sprintf("%d", parsedRecid)
-		}
-
-		client := searcher.NewClient(server)
-		record, err := client.GetRecord(parsedRecid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to get record: %v", err))
-			os.Exit(1)
-		}
-
-		if protocol == "" {
-			if downloadEngine == "xrootd" {
-				protocol = "xrootd"
-			} else {
-				protocol = "http"
+		RunE: func(cmd *cobra.Command, args []string) error {
+			recid, err := cmd.Flags().GetInt("recid")
+			if err != nil {
+				return commandErrorf("Invalid recid: %w", err)
 			}
-		}
+			doi, _ := cmd.Flags().GetString("doi")
+			title, _ := cmd.Flags().GetString("title")
+			outputDir, _ := cmd.Flags().GetString("output-dir")
+			filterName, _ := cmd.Flags().GetString("filter-name")
+			filterRegexp, _ := cmd.Flags().GetString("filter-regexp")
+			filterRange, _ := cmd.Flags().GetString("filter-range")
+			expand, _ := cmd.Flags().GetBool("expand")
+			noExpand, _ := cmd.Flags().GetBool("no-expand")
+			retryLimit, _ := cmd.Flags().GetInt("retry-limit")
+			retrySleep, _ := cmd.Flags().GetInt("retry-sleep")
+			verbose, _ := cmd.Flags().GetBool("verbose")
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			verifyFlag, _ := cmd.Flags().GetBool("verify")
+			downloadEngine, _ := cmd.Flags().GetString("download-engine")
+			protocol, _ := cmd.Flags().GetString("protocol")
+			server, _ := cmd.Flags().GetString("server")
+			fileAvailability, _ := cmd.Flags().GetString("file-availability")
 
-		files, err := client.GetFilesList(record, protocol, expand)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to get files list: %v", err))
-			os.Exit(1)
-		}
-		totalFiles := len(files)
-		var totalBytes int64
-		for _, f := range files {
-			totalBytes += f.Size
-		}
+			if fileAvailability != "" && fileAvailability != "online" && fileAvailability != "all" {
+				return commandErrorf("Invalid file availability: %s (choose from 'online', 'all')", fileAvailability)
+			}
 
-		tapeFilesSkipped := 0
-		if expand {
-			// Check if we have offline files
-			hasOfflineFiles := false
-			for _, f := range files {
-				if f.Availability != "" && f.Availability != "online" {
-					hasOfflineFiles = true
-					break
+			if cmd.Flags().Changed("expand") && cmd.Flags().Changed("no-expand") {
+				return commandErrorf("Cannot specify both --expand and --no-expand")
+			}
+
+			if noExpand {
+				expand = false
+			}
+
+			if server == "" {
+				server = config.ServerHTTPURI
+			}
+
+			parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
+			if err != nil {
+				return commandErrorf("Failed to find record: %w", err)
+			}
+
+			if outputDir == "" {
+				outputDir = fmt.Sprintf("%d", parsedRecid)
+			}
+
+			client := searcher.NewClient(server)
+			record, err := client.GetRecord(parsedRecid)
+			if err != nil {
+				return commandErrorf("Failed to get record: %w", err)
+			}
+
+			if protocol == "" {
+				if downloadEngine == "xrootd" {
+					protocol = "xrootd"
+				} else {
+					protocol = "http"
 				}
 			}
 
-			// Apply filtering logic
-			if fileAvailability == "online" {
-				files, _ = searcher.FilterFilesByAvailability(files, "online")
-			} else if fileAvailability == "" && hasOfflineFiles {
-				// Default behavior: warn and skip offline files
-				printer.DisplayMessage(printer.Warning, "Some files are stored on tape and will be skipped.")
-				printer.DisplayMessage(printer.Warning, fmt.Sprintf("Visit https://opendata.cern.ch/record/%d to request file staging.", parsedRecid))
-				printer.DisplayMessage(printer.Warning, "Use '--file-availability all' to force attempting to download all files.")
-				files, _ = searcher.FilterFilesByAvailability(files, "online")
-			}
-			// If "all", we keep everything (user explicitly requested it)
-
-			tapeFilesSkipped = totalFiles - len(files)
-		}
-		fileList := files
-
-		if filterName != "" {
-			nameFilters := strings.Split(filterName, ",")
-			for i, filter := range nameFilters {
-				nameFilters[i] = strings.TrimSpace(filter)
-			}
-			fileList = downloader.FilterFilesByMultipleNames(fileList, nameFilters)
-		}
-
-		if filterRegexp != "" {
-			fileList = downloader.FilterFilesByRegex(fileList, filterRegexp)
-		}
-
-		if filterRange != "" {
-			ranges, err := utils.ParseRanges([]string{filterRange})
+			files, err := client.GetFilesList(record, protocol, expand)
 			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid range filter: %v", err))
-				os.Exit(1)
+				return commandErrorf("Failed to get files list: %w", err)
 			}
-			fileList = downloader.FilterFilesByMultipleRanges(fileList, ranges)
-		}
-
-		if len(fileList) == 0 {
-			printer.DisplayMessage(printer.Error, "No files matching filters")
-			os.Exit(1)
-		}
-
-		var stats downloader.DownloadStats
-		if downloadEngine == "xrootd" {
-			xrdDownloader := xrootddownloader.NewDownloader()
-			defer func() {
-				_ = xrdDownloader.Close()
-			}()
-			// Enable progress when --progress or --verbose flags are set
-			showProgress := verbose
-			if progressFlag, _ := cmd.Flags().GetBool("progress"); progressFlag {
-				showProgress = true
-			}
-			stats = xrdDownloader.DownloadFiles(cmd.Context(), fileList, outputDir, retryLimit, retrySleep, verbose, dryRun, showProgress)
-		} else {
-			httpDownloader := downloader.NewDownloader()
-			// Enable progress when --progress or --verbose flags are set
-			showProgress := verbose
-			if progressFlag, _ := cmd.Flags().GetBool("progress"); progressFlag {
-				showProgress = true
-			}
-			stats = httpDownloader.DownloadFiles(fileList, outputDir, retryLimit, retrySleep, verbose, dryRun, showProgress)
-		}
-
-		if verifyFlag {
-			printer.DisplayMessage(printer.Info, "\nVerifying downloaded files...")
-			v := verifier.NewVerifier()
-			verifyStats, err := v.VerifyFiles(outputDir, fileList)
-			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Verification failed: %v", err))
-				os.Exit(1)
+			totalFiles := len(files)
+			var totalBytes int64
+			for _, f := range files {
+				totalBytes += f.Size
 			}
 
-			if verifyStats.SizeFailed > 0 || verifyStats.ChecksumFailed > 0 {
-				printer.DisplayMessage(printer.Error, "Some files failed verification")
-				os.Exit(1)
+			tapeFilesSkipped := 0
+			if expand {
+				// Check if we have offline files
+				hasOfflineFiles := false
+				for _, f := range files {
+					if f.Availability != "" && f.Availability != "online" {
+						hasOfflineFiles = true
+						break
+					}
+				}
+
+				// Apply filtering logic
+				if fileAvailability == "online" {
+					files, _ = searcher.FilterFilesByAvailability(files, "online")
+				} else if fileAvailability == "" && hasOfflineFiles {
+					// Default behavior: warn and skip offline files
+					printer.DisplayMessage(printer.Warning, "Some files are stored on tape and will be skipped.")
+					printer.DisplayMessage(printer.Warning, fmt.Sprintf("Visit https://opendata.cern.ch/record/%d to request file staging.", parsedRecid))
+					printer.DisplayMessage(printer.Warning, "Use '--file-availability all' to force attempting to download all files.")
+					files, _ = searcher.FilterFilesByAvailability(files, "online")
+				}
+				// If "all", we keep everything (user explicitly requested it)
+
+				tapeFilesSkipped = totalFiles - len(files)
 			}
-		}
+			fileList := files
 
-		if stats.FailedFiles == 0 {
-			printer.DisplayMessage(printer.Info, "Success!")
-		}
+			if filterName != "" {
+				nameFilters := strings.Split(filterName, ",")
+				for i, filter := range nameFilters {
+					nameFilters[i] = strings.TrimSpace(filter)
+				}
+				fileList = downloader.FilterFilesByMultipleNames(fileList, nameFilters)
+			}
 
-		// Print summary statistics
-		printer.DisplayOutput("")
-		printer.DisplayOutput("Summary:")
-		printer.DisplayOutput(fmt.Sprintf("- Files downloaded: %d / %d", stats.DownloadedFiles, totalFiles))
-		if tapeFilesSkipped > 0 {
-			printer.DisplayOutput(fmt.Sprintf("- Files skipped (on tape): %d", tapeFilesSkipped))
-		}
-		printer.DisplayOutput(fmt.Sprintf("- Bytes downloaded: %s / %s", utils.FormatBytes(float64(stats.DownloadedBytes)), utils.FormatBytes(float64(totalBytes))))
+			if filterRegexp != "" {
+				fileList = downloader.FilterFilesByRegex(fileList, filterRegexp)
+			}
 
-		if stats.FailedFiles > 0 {
-			os.Exit(1)
-		}
-	},
-}
+			if filterRange != "" {
+				ranges, err := utils.ParseRanges([]string{filterRange})
+				if err != nil {
+					return commandErrorf("Invalid range filter: %w", err)
+				}
+				fileList = downloader.FilterFilesByMultipleRanges(fileList, ranges)
+			}
 
-func init() {
-	downloadFilesCmd.Flags().IntP("recid", "R", 0, "Record ID (exact match)")
-	downloadFilesCmd.Flags().StringP("doi", "d", "", "Digital Object Identifier (exact match)")
-	downloadFilesCmd.Flags().StringP("title", "t", "", "Record title (exact match, no wildcards)")
-	downloadFilesCmd.Flags().StringP("output-dir", "O", "", "Output directory")
-	downloadFilesCmd.Flags().StringP("filter-name", "n", "", "Download files matching exactly the file name")
-	downloadFilesCmd.Flags().StringP("filter-regexp", "e", "", "Download files matching the regular expression")
-	downloadFilesCmd.Flags().StringP("filter-range", "r", "", "Download files from a specified list range (i-j)")
-	downloadFilesCmd.Flags().BoolP("expand", "x", true, "Expand file indexes?")
-	downloadFilesCmd.Flags().Bool("no-expand", false, "Don't expand file indexes")
-	downloadFilesCmd.Flags().IntP("retry-limit", "y", 10, "Number of retries when downloading a file")
-	downloadFilesCmd.Flags().IntP("retry-sleep", "Y", 5, "Sleep time in seconds before retrying downloads")
-	downloadFilesCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
-	downloadFilesCmd.Flags().BoolP("progress", "P", false, "Show progress (alias for verbose)")
-	downloadFilesCmd.Flags().BoolP("dry-run", "N", false, "Dry run (don't actually download)")
-	downloadFilesCmd.Flags().BoolP("verify", "V", false, "Verify downloaded files")
-	downloadFilesCmd.Flags().String("download-engine", "", "Download engine to use (http|xrootd)")
-	downloadFilesCmd.Flags().StringP("protocol", "p", "", "Protocol to be used in links [http,xrootd]")
-	downloadFilesCmd.Flags().StringP("server", "s", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
-	downloadFilesCmd.Flags().StringP("file-availability", "", "", "Filter files by their availability status [online, all]")
+			if len(fileList) == 0 {
+				return commandErrorf("No files matching filters")
+			}
+
+			var stats downloader.DownloadStats
+			if downloadEngine == "xrootd" {
+				xrdDownloader := newXRootDDownloader()
+				defer func() {
+					_ = xrdDownloader.Close()
+				}()
+				// Enable progress when --progress or --verbose flags are set
+				showProgress := verbose
+				if progressFlag, _ := cmd.Flags().GetBool("progress"); progressFlag {
+					showProgress = true
+				}
+				stats = xrdDownloader.DownloadFiles(cmd.Context(), fileList, outputDir, retryLimit, retrySleep, verbose, dryRun, showProgress)
+			} else {
+				httpDownloader := downloader.NewDownloader()
+				// Enable progress when --progress or --verbose flags are set
+				showProgress := verbose
+				if progressFlag, _ := cmd.Flags().GetBool("progress"); progressFlag {
+					showProgress = true
+				}
+				stats = httpDownloader.DownloadFiles(fileList, outputDir, retryLimit, retrySleep, verbose, dryRun, showProgress)
+			}
+
+			if verifyFlag {
+				printer.DisplayMessage(printer.Info, "\nVerifying downloaded files...")
+				v := verifier.NewVerifier()
+				verifyStats, err := v.VerifyFiles(outputDir, fileList)
+				if err != nil {
+					return commandErrorf("Verification failed: %w", err)
+				}
+
+				if verifyStats.SizeFailed > 0 || verifyStats.ChecksumFailed > 0 {
+					return commandErrorf("Some files failed verification")
+				}
+			}
+
+			if stats.FailedFiles == 0 {
+				printer.DisplayMessage(printer.Info, "Success!")
+			}
+
+			// Print summary statistics
+			printer.DisplayOutput("")
+			printer.DisplayOutput("Summary:")
+			printer.DisplayOutput(fmt.Sprintf("- Files downloaded: %d / %d", stats.DownloadedFiles, totalFiles))
+			if tapeFilesSkipped > 0 {
+				printer.DisplayOutput(fmt.Sprintf("- Files skipped (on tape): %d", tapeFilesSkipped))
+			}
+			printer.DisplayOutput(fmt.Sprintf("- Bytes downloaded: %s / %s", utils.FormatBytes(float64(stats.DownloadedBytes)), utils.FormatBytes(float64(totalBytes))))
+
+			if stats.FailedFiles > 0 {
+				return fmt.Errorf("%d file(s) failed to download", stats.FailedFiles)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntP("recid", "R", 0, "Record ID (exact match)")
+	cmd.Flags().StringP("doi", "d", "", "Digital Object Identifier (exact match)")
+	cmd.Flags().StringP("title", "t", "", "Record title (exact match, no wildcards)")
+	cmd.Flags().StringP("output-dir", "O", "", "Output directory")
+	cmd.Flags().StringP("filter-name", "n", "", "Download files matching exactly the file name")
+	cmd.Flags().StringP("filter-regexp", "e", "", "Download files matching the regular expression")
+	cmd.Flags().StringP("filter-range", "r", "", "Download files from a specified list range (i-j)")
+	cmd.Flags().BoolP("expand", "x", true, "Expand file indexes?")
+	cmd.Flags().Bool("no-expand", false, "Don't expand file indexes")
+	cmd.Flags().IntP("retry-limit", "y", 10, "Number of retries when downloading a file")
+	cmd.Flags().IntP("retry-sleep", "Y", 5, "Sleep time in seconds before retrying downloads")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+	cmd.Flags().BoolP("progress", "P", false, "Show progress (alias for verbose)")
+	cmd.Flags().BoolP("dry-run", "N", false, "Dry run (don't actually download)")
+	cmd.Flags().BoolP("verify", "V", false, "Verify downloaded files")
+	cmd.Flags().String("download-engine", "", "Download engine to use (http|xrootd)")
+	cmd.Flags().StringP("protocol", "p", "", "Protocol to be used in links [http,xrootd]")
+	cmd.Flags().StringP("server", "s", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
+	cmd.Flags().StringP("file-availability", "", "", "Filter files by their availability status [online, all]")
+	return cmd
 }

--- a/cmd/cernopendata-client/get_file_locations.go
+++ b/cmd/cernopendata-client/get_file_locations.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,10 +11,11 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/searcher"
 )
 
-var getFileLocationsCmd = &cobra.Command{
-	Use:   "get-file-locations",
-	Short: "Get a list of data file locations of a record",
-	Long: `Get a list of data file locations of a record.
+func newGetFileLocationsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-file-locations",
+		Short: "Get a list of data file locations of a record",
+		Long: `Get a list of data file locations of a record.
 
 Select a CERN Open Data bibliographic record by a record ID, a DOI, or a
 title and return the list of data file locations belonging to this record.
@@ -31,119 +31,111 @@ Examples:
      $ cernopendata-client get-file-locations --recid 8886 --file-availability online
 
      $ cernopendata-client get-file-locations --recid 5500 --format json`,
-	Run: func(cmd *cobra.Command, args []string) {
-		recid, err := cmd.Flags().GetInt("recid")
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid recid: %v", err))
-			os.Exit(1)
-		}
-		doi, _ := cmd.Flags().GetString("doi")
-		title, _ := cmd.Flags().GetString("title")
-		protocol, _ := cmd.Flags().GetString("protocol")
-		expand, _ := cmd.Flags().GetBool("expand")
-		noExpand, _ := cmd.Flags().GetBool("no-expand")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-		fileAvailability, _ := cmd.Flags().GetString("file-availability")
-		server, _ := cmd.Flags().GetString("server")
-		outputFormat, _ := cmd.Flags().GetString("format")
-
-		if fileAvailability != "" && fileAvailability != "online" && fileAvailability != "all" {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid file availability: %s (choose from 'online', 'all')", fileAvailability))
-			os.Exit(1)
-		}
-
-		if outputFormat != "text" && outputFormat != "json" {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid format: %s (choose from 'text', 'json')", outputFormat))
-			os.Exit(1)
-		}
-
-		if cmd.Flags().Changed("expand") && cmd.Flags().Changed("no-expand") {
-			printer.DisplayMessage(printer.Error, "Cannot specify both --expand and --no-expand")
-			os.Exit(1)
-		}
-
-		if noExpand {
-			expand = false
-		}
-
-		if server == "" {
-			server = config.ServerHTTPURI
-		}
-
-		parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to find record: %v", err))
-			os.Exit(1)
-		}
-
-		client := searcher.NewClient(server)
-		record, err := client.GetRecord(parsedRecid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to get record: %v", err))
-			os.Exit(1)
-		}
-
-		files, err := client.GetFilesList(record, protocol, expand)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to list files: %v", err))
-			os.Exit(1)
-		}
-
-		if expand {
-			filteredFiles, hasOfflineWarning := searcher.FilterFilesByAvailability(files, fileAvailability)
-			if hasOfflineWarning && fileAvailability == "" {
-				printer.DisplayMessage(printer.Warning, "WARNING: Some files in the list are not online and may not be downloadable.")
-				printer.DisplayMessage(printer.Warning, "To list only online files, use the '--file-availability online' option.")
-			}
-			files = filteredFiles
-		}
-
-		if outputFormat == "json" {
-			type FileOutput struct {
-				URI          string `json:"uri"`
-				Size         int64  `json:"size,omitempty"`
-				Checksum     string `json:"checksum,omitempty"`
-				Availability string `json:"availability,omitempty"`
-			}
-
-			var output []FileOutput
-			for _, file := range files {
-				output = append(output, FileOutput{
-					URI:          file.URI,
-					Size:         file.Size,
-					Checksum:     file.Checksum,
-					Availability: file.Availability,
-				})
-			}
-
-			jsonBytes, err := json.MarshalIndent(output, "", "  ")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			recid, err := cmd.Flags().GetInt("recid")
 			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to marshal JSON: %v", err))
-				os.Exit(1)
+				return commandErrorf("Invalid recid: %w", err)
 			}
-			printer.DisplayOutput(string(jsonBytes))
-			return
-		}
+			doi, _ := cmd.Flags().GetString("doi")
+			title, _ := cmd.Flags().GetString("title")
+			protocol, _ := cmd.Flags().GetString("protocol")
+			expand, _ := cmd.Flags().GetBool("expand")
+			noExpand, _ := cmd.Flags().GetBool("no-expand")
+			verbose, _ := cmd.Flags().GetBool("verbose")
+			fileAvailability, _ := cmd.Flags().GetString("file-availability")
+			server, _ := cmd.Flags().GetString("server")
+			outputFormat, _ := cmd.Flags().GetString("format")
 
-		for _, file := range files {
-			if verbose {
-				printer.DisplayOutput(fmt.Sprintf("%s\t%d\t%s\t%s", file.URI, file.Size, file.Checksum, file.Availability))
-			} else {
-				printer.DisplayOutput(file.URI)
+			if fileAvailability != "" && fileAvailability != "online" && fileAvailability != "all" {
+				return commandErrorf("Invalid file availability: %s (choose from 'online', 'all')", fileAvailability)
 			}
-		}
-	},
-}
 
-func init() {
-	getFileLocationsCmd.Flags().IntP("recid", "i", 0, "Record ID (exact match)")
-	getFileLocationsCmd.Flags().StringP("doi", "D", "", "Digital Object Identifier (exact match)")
-	getFileLocationsCmd.Flags().StringP("title", "T", "", "Record title (exact match, no wildcards)")
-	getFileLocationsCmd.Flags().StringP("protocol", "p", "http", "Protocol to be used in links [http,xrootd]")
-	getFileLocationsCmd.Flags().BoolP("expand", "e", true, "Expand file indexes?")
-	getFileLocationsCmd.Flags().Bool("no-expand", false, "Don't expand file indexes")
-	getFileLocationsCmd.Flags().BoolP("verbose", "V", false, "Output also the file size (2nd), checksum (3rd), and availability (4th)")
-	getFileLocationsCmd.Flags().StringP("file-availability", "", "", "Filter files by their availability status [online, all]")
-	getFileLocationsCmd.Flags().StringP("server", "S", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
-	getFileLocationsCmd.Flags().StringP("format", "m", "text", "Output format (text|json)")
+			if outputFormat != "text" && outputFormat != "json" {
+				return commandErrorf("Invalid format: %s (choose from 'text', 'json')", outputFormat)
+			}
+
+			if cmd.Flags().Changed("expand") && cmd.Flags().Changed("no-expand") {
+				return commandErrorf("Cannot specify both --expand and --no-expand")
+			}
+
+			if noExpand {
+				expand = false
+			}
+
+			if server == "" {
+				server = config.ServerHTTPURI
+			}
+
+			parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
+			if err != nil {
+				return commandErrorf("Failed to find record: %w", err)
+			}
+
+			client := searcher.NewClient(server)
+			record, err := client.GetRecord(parsedRecid)
+			if err != nil {
+				return commandErrorf("Failed to get record: %w", err)
+			}
+
+			files, err := client.GetFilesList(record, protocol, expand)
+			if err != nil {
+				return commandErrorf("Failed to list files: %w", err)
+			}
+
+			if expand {
+				filteredFiles, hasOfflineWarning := searcher.FilterFilesByAvailability(files, fileAvailability)
+				if hasOfflineWarning && fileAvailability == "" {
+					printer.DisplayMessage(printer.Warning, "WARNING: Some files in the list are not online and may not be downloadable.")
+					printer.DisplayMessage(printer.Warning, "To list only online files, use the '--file-availability online' option.")
+				}
+				files = filteredFiles
+			}
+
+			if outputFormat == "json" {
+				type FileOutput struct {
+					URI          string `json:"uri"`
+					Size         int64  `json:"size,omitempty"`
+					Checksum     string `json:"checksum,omitempty"`
+					Availability string `json:"availability,omitempty"`
+				}
+
+				var output []FileOutput
+				for _, file := range files {
+					output = append(output, FileOutput{
+						URI:          file.URI,
+						Size:         file.Size,
+						Checksum:     file.Checksum,
+						Availability: file.Availability,
+					})
+				}
+
+				jsonBytes, err := json.MarshalIndent(output, "", "  ")
+				if err != nil {
+					return commandErrorf("Failed to marshal JSON: %w", err)
+				}
+				printer.DisplayOutput(string(jsonBytes))
+				return nil
+			}
+
+			for _, file := range files {
+				if verbose {
+					printer.DisplayOutput(fmt.Sprintf("%s\t%d\t%s\t%s", file.URI, file.Size, file.Checksum, file.Availability))
+				} else {
+					printer.DisplayOutput(file.URI)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntP("recid", "i", 0, "Record ID (exact match)")
+	cmd.Flags().StringP("doi", "D", "", "Digital Object Identifier (exact match)")
+	cmd.Flags().StringP("title", "T", "", "Record title (exact match, no wildcards)")
+	cmd.Flags().StringP("protocol", "p", "http", "Protocol to be used in links [http,xrootd]")
+	cmd.Flags().BoolP("expand", "e", true, "Expand file indexes?")
+	cmd.Flags().Bool("no-expand", false, "Don't expand file indexes")
+	cmd.Flags().BoolP("verbose", "V", false, "Output also the file size (2nd), checksum (3rd), and availability (4th)")
+	cmd.Flags().StringP("file-availability", "", "", "Filter files by their availability status [online, all]")
+	cmd.Flags().StringP("server", "S", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
+	cmd.Flags().StringP("format", "m", "text", "Output format (text|json)")
+	return cmd
 }

--- a/cmd/cernopendata-client/get_metadata.go
+++ b/cmd/cernopendata-client/get_metadata.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,10 +11,11 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/searcher"
 )
 
-var getMetadataCmd = &cobra.Command{
-	Use:   "get-metadata",
-	Short: "Get metadata content of a record",
-	Long: `Get metadata content of a record.
+func newGetMetadataCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-metadata",
+		Short: "Get metadata content of a record",
+		Long: `Get metadata content of a record.
 
 Select a CERN Open Data bibliographic record by a record ID, a
 DOI, or a title and return its metadata in the JSON format.
@@ -27,96 +27,87 @@ Examples:
      $ cernopendata-client get-metadata --recid 1 --output-value title
 
      $ cernopendata-client get-metadata --recid 329 --output-value authors.orcid --filter name="Rousseau, David"`,
-	Run: func(cmd *cobra.Command, args []string) {
-		recid, err := cmd.Flags().GetInt("recid")
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid recid: %v", err))
-			os.Exit(1)
-		}
-		doi, _ := cmd.Flags().GetString("doi")
-		title, _ := cmd.Flags().GetString("title")
-		outputValue, _ := cmd.Flags().GetString("output-value")
-		filterStr, _ := cmd.Flags().GetString("filter")
-		outputFormat, _ := cmd.Flags().GetString("format")
-		server, _ := cmd.Flags().GetString("server")
-
-		if server == "" {
-			server = config.ServerHTTPURI
-		}
-
-		if filterStr != "" && outputValue == "" {
-			printer.DisplayMessage(printer.Error, "--filter can only be used with --output-value")
-			os.Exit(1)
-		}
-
-		parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to find record: %v", err))
-			os.Exit(1)
-		}
-
-		client := searcher.NewClient(server)
-		record, err := client.GetRecord(parsedRecid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to get metadata: %v", err))
-			os.Exit(1)
-		}
-
-		var filters []string
-		if filterStr != "" {
-			filters = []string{filterStr}
-		}
-
-		if outputValue == "" {
-			output, err := metadater.FormatOutput(record.Metadata, outputFormat)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			recid, err := cmd.Flags().GetInt("recid")
 			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to format output: %v", err))
-				os.Exit(1)
+				return commandErrorf("Invalid recid: %w", err)
 			}
-			printer.DisplayOutput(output)
-		} else {
-			metadata, err := metadater.GetNestedField(record.Metadata, outputValue)
-			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Field not found: %v", err))
-				os.Exit(1)
+			doi, _ := cmd.Flags().GetString("doi")
+			title, _ := cmd.Flags().GetString("title")
+			outputValue, _ := cmd.Flags().GetString("output-value")
+			filterStr, _ := cmd.Flags().GetString("filter")
+			outputFormat, _ := cmd.Flags().GetString("format")
+			server, _ := cmd.Flags().GetString("server")
+
+			if server == "" {
+				server = config.ServerHTTPURI
 			}
 
-			if len(filters) > 0 {
-				items, isArray := metadata.([]any)
-				if !isArray {
-					items = []any{metadata}
-				}
-				filtered, err := metadater.FilterArray(items, filters)
+			if filterStr != "" && outputValue == "" {
+				return fmt.Errorf("--filter can only be used with --output-value")
+			}
+
+			parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
+			if err != nil {
+				return commandErrorf("Failed to find record: %w", err)
+			}
+
+			client := searcher.NewClient(server)
+			record, err := client.GetRecord(parsedRecid)
+			if err != nil {
+				return commandErrorf("Failed to get metadata: %w", err)
+			}
+
+			var filters []string
+			if filterStr != "" {
+				filters = []string{filterStr}
+			}
+
+			if outputValue == "" {
+				output, err := metadater.FormatOutput(record.Metadata, outputFormat)
 				if err != nil {
-					printer.DisplayMessage(printer.Error, fmt.Sprintf("Filter error: %v", err))
-					os.Exit(1)
+					return commandErrorf("Failed to format output: %w", err)
 				}
-				if len(filtered) > 0 {
-					output, err := metadater.FormatOutput(filtered[0], outputFormat)
+				printer.DisplayOutput(output)
+			} else {
+				metadata, err := metadater.GetNestedField(record.Metadata, outputValue)
+				if err != nil {
+					return commandErrorf("Field not found: %w", err)
+				}
+
+				if len(filters) > 0 {
+					items, isArray := metadata.([]any)
+					if !isArray {
+						items = []any{metadata}
+					}
+					filtered, err := metadater.FilterArray(items, filters)
 					if err != nil {
-						printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to format output: %v", err))
-						os.Exit(1)
+						return commandErrorf("Filter error: %w", err)
+					}
+					if len(filtered) > 0 {
+						output, err := metadater.FormatOutput(filtered[0], outputFormat)
+						if err != nil {
+							return commandErrorf("Failed to format output: %w", err)
+						}
+						printer.DisplayOutput(output)
+					}
+				} else {
+					output, err := metadater.FormatOutput(metadata, outputFormat)
+					if err != nil {
+						return commandErrorf("Failed to format output: %w", err)
 					}
 					printer.DisplayOutput(output)
 				}
-			} else {
-				output, err := metadater.FormatOutput(metadata, outputFormat)
-				if err != nil {
-					printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to format output: %v", err))
-					os.Exit(1)
-				}
-				printer.DisplayOutput(output)
 			}
-		}
-	},
-}
-
-func init() {
-	getMetadataCmd.Flags().IntP("recid", "r", 0, "Record ID (exact match)")
-	getMetadataCmd.Flags().StringP("doi", "d", "", "Digital Object Identifier (exact match)")
-	getMetadataCmd.Flags().StringP("title", "t", "", "Record title (exact match, no wildcards)")
-	getMetadataCmd.Flags().StringP("output-value", "v", "", "Output value of only desired metadata field [example=title]")
-	getMetadataCmd.Flags().StringP("filter", "f", "", "Filter only certain output values matching filtering criteria. [Use --filter some_field_name=some_value]")
-	getMetadataCmd.Flags().StringP("format", "m", "pretty", "Output format (pretty|json)")
-	getMetadataCmd.Flags().StringP("server", "s", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
+			return nil
+		},
+	}
+	cmd.Flags().IntP("recid", "r", 0, "Record ID (exact match)")
+	cmd.Flags().StringP("doi", "d", "", "Digital Object Identifier (exact match)")
+	cmd.Flags().StringP("title", "t", "", "Record title (exact match, no wildcards)")
+	cmd.Flags().StringP("output-value", "v", "", "Output value of only desired metadata field [example=title]")
+	cmd.Flags().StringP("filter", "f", "", "Filter only certain output values matching filtering criteria. [Use --filter some_field_name=some_value]")
+	cmd.Flags().StringP("format", "m", "pretty", "Output format (pretty|json)")
+	cmd.Flags().StringP("server", "s", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
+	return cmd
 }

--- a/cmd/cernopendata-client/list_directory.go
+++ b/cmd/cernopendata-client/list_directory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -29,10 +28,11 @@ func printEntries(entries []lister.FileInfo, verbose bool) {
 	}
 }
 
-var listDirectoryCmd = &cobra.Command{
-	Use:   "list-directory [path]",
-	Short: "List contents of a EOSPUBLIC Open Data directory.",
-	Long: `List contents of a EOSPUBLIC Open Data directory.
+func newListDirectoryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-directory [path]",
+		Short: "List contents of a EOSPUBLIC Open Data directory.",
+		Long: `List contents of a EOSPUBLIC Open Data directory.
 
 Returns the list of files and subdirectories of a given EOSPUBLIC directory.
 
@@ -45,82 +45,78 @@ Examples:
      $ cernopendata-client list-directory /eos/opendata/cms/Run2010B --recursive --timeout 10
 
      $ cernopendata-client list-directory /eos/opendata/cms/Run2010B --format json`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		path := args[0]
-		recursive, _ := cmd.Flags().GetBool("recursive")
-		timeout, _ := cmd.Flags().GetInt("timeout")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-		outputFormat, _ := cmd.Flags().GetString("format")
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			recursive, _ := cmd.Flags().GetBool("recursive")
+			timeout, _ := cmd.Flags().GetInt("timeout")
+			verbose, _ := cmd.Flags().GetBool("verbose")
+			outputFormat, _ := cmd.Flags().GetString("format")
 
-		if outputFormat != "text" && outputFormat != "json" {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid format: %s (choose from 'text', 'json')", outputFormat))
-			os.Exit(1)
-		}
-
-		ctx := cmd.Context()
-		if timeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-			defer cancel()
-		}
-
-		l := lister.NewLister()
-
-		var entries []lister.FileInfo
-		var err error
-
-		if recursive {
-			entries, err = l.ListDirectoryRecursive(ctx, path)
-			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to list directory: %v", err))
-				os.Exit(1)
-			}
-		} else {
-			entries, err = l.ListDirectory(ctx, path)
-			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to list directory: %v", err))
-				os.Exit(1)
-			}
-		}
-
-		if outputFormat == "json" {
-			type DirOutput struct {
-				Name    string `json:"name"`
-				Size    int64  `json:"size,omitempty"`
-				ModTime string `json:"mod_time,omitempty"`
-				IsDir   bool   `json:"is_dir"`
+			if outputFormat != "text" && outputFormat != "json" {
+				return commandErrorf("Invalid format: %s (choose from 'text', 'json')", outputFormat)
 			}
 
-			var output []DirOutput
-			for _, entry := range entries {
-				dirEntry := DirOutput{
-					Name:  entry.Name,
-					IsDir: entry.IsDir,
+			ctx := cmd.Context()
+			if timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+				defer cancel()
+			}
+
+			l := lister.NewLister()
+
+			var entries []lister.FileInfo
+			var err error
+
+			if recursive {
+				entries, err = l.ListDirectoryRecursive(ctx, path)
+				if err != nil {
+					return commandErrorf("Failed to list directory: %w", err)
 				}
-				if verbose {
-					dirEntry.Size = entry.Size
-					dirEntry.ModTime = entry.ModTime
+			} else {
+				entries, err = l.ListDirectory(ctx, path)
+				if err != nil {
+					return commandErrorf("Failed to list directory: %w", err)
 				}
-				output = append(output, dirEntry)
 			}
 
-			jsonBytes, err := json.MarshalIndent(output, "", "  ")
-			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to marshal JSON: %v", err))
-				os.Exit(1)
+			if outputFormat == "json" {
+				type DirOutput struct {
+					Name    string `json:"name"`
+					Size    int64  `json:"size,omitempty"`
+					ModTime string `json:"mod_time,omitempty"`
+					IsDir   bool   `json:"is_dir"`
+				}
+
+				var output []DirOutput
+				for _, entry := range entries {
+					dirEntry := DirOutput{
+						Name:  entry.Name,
+						IsDir: entry.IsDir,
+					}
+					if verbose {
+						dirEntry.Size = entry.Size
+						dirEntry.ModTime = entry.ModTime
+					}
+					output = append(output, dirEntry)
+				}
+
+				jsonBytes, err := json.MarshalIndent(output, "", "  ")
+				if err != nil {
+					return commandErrorf("Failed to marshal JSON: %w", err)
+				}
+				printer.DisplayOutput(string(jsonBytes))
+				return nil
 			}
-			printer.DisplayOutput(string(jsonBytes))
-			return
-		}
 
-		printEntries(entries, verbose)
-	},
-}
-
-func init() {
-	listDirectoryCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
-	listDirectoryCmd.Flags().BoolP("recursive", "r", false, "Iterate recursively in the given directory path")
-	listDirectoryCmd.Flags().IntP("timeout", "t", config.ListDirectoryTimeout, "Timeout in seconds after which to exit running the command")
-	listDirectoryCmd.Flags().StringP("format", "m", "text", "Output format (text|json)")
+			printEntries(entries, verbose)
+			return nil
+		},
+	}
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+	cmd.Flags().BoolP("recursive", "r", false, "Iterate recursively in the given directory path")
+	cmd.Flags().IntP("timeout", "t", config.ListDirectoryTimeout, "Timeout in seconds after which to exit running the command")
+	cmd.Flags().StringP("format", "m", "text", "Output format (text|json)")
+	return cmd
 }

--- a/cmd/cernopendata-client/main.go
+++ b/cmd/cernopendata-client/main.go
@@ -19,52 +19,73 @@ func init() {
 }
 
 func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "cernopendata-client",
-		Short: "CLI for CERN Open Data portal",
+	if exitCode := execute(newRootCommand()); exitCode != 0 {
+		os.Exit(exitCode)
+	}
+}
+
+func execute(rootCmd *cobra.Command) int {
+	if err := rootCmd.Execute(); err != nil {
+		printer.DisplayMessage(printer.Error, fmt.Sprintf("Error: %v", err))
+		return 1
+	}
+	return 0
+}
+
+func commandErrorf(format string, args ...any) error {
+	return fmt.Errorf(format, args...)
+}
+
+func newRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:           "cernopendata-client",
+		Short:         "CLI for CERN Open Data portal",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				_ = cmd.Help()
-				return nil
+				return cmd.Help()
 			}
 			return fmt.Errorf("unknown command: %s", args[0])
 		},
 	}
 
-	var completionCmd = &cobra.Command{
+	rootCmd.AddCommand(newVersionCommand())
+	rootCmd.AddCommand(newUpdateCommand())
+	rootCmd.AddCommand(newGetMetadataCommand())
+	rootCmd.AddCommand(newGetFileLocationsCommand())
+	rootCmd.AddCommand(newDownloadFilesCommand())
+	rootCmd.AddCommand(newVerifyFilesCommand())
+	rootCmd.AddCommand(newListDirectoryCommand())
+	rootCmd.AddCommand(newSearchCommand())
+	rootCmd.AddCommand(newCompletionCommand(rootCmd))
+
+	return rootCmd
+}
+
+func newCompletionCommand(rootCmd *cobra.Command) *cobra.Command {
+	return &cobra.Command{
 		Use:   "completion",
 		Short: "Generate shell completion script",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				printer.DisplayMessage(printer.Error, "Please specify bash or zsh")
-				os.Exit(1)
+				return commandErrorf("Please specify bash or zsh")
 			}
 
 			shell := args[0]
 			switch shell {
 			case "bash":
-				_ = rootCmd.GenBashCompletion(os.Stdout)
+				if err := rootCmd.GenBashCompletion(cmd.OutOrStdout()); err != nil {
+					return commandErrorf("Failed to generate bash completion: %w", err)
+				}
 			case "zsh":
-				_ = rootCmd.GenZshCompletion(os.Stdout)
+				if err := rootCmd.GenZshCompletion(cmd.OutOrStdout()); err != nil {
+					return commandErrorf("Failed to generate zsh completion: %w", err)
+				}
 			default:
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Unsupported shell: %s (supported: bash, zsh)", shell))
-				os.Exit(1)
+				return commandErrorf("Unsupported shell: %s (supported: bash, zsh)", shell)
 			}
+			return nil
 		},
-	}
-
-	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(updateCmd)
-	rootCmd.AddCommand(getMetadataCmd)
-	rootCmd.AddCommand(getFileLocationsCmd)
-	rootCmd.AddCommand(downloadFilesCmd)
-	rootCmd.AddCommand(verifyFilesCmd)
-	rootCmd.AddCommand(listDirectoryCmd)
-	rootCmd.AddCommand(searchCmd)
-	rootCmd.AddCommand(completionCmd)
-
-	if err := rootCmd.Execute(); err != nil {
-		printer.DisplayMessage(printer.Error, fmt.Sprintf("Error: %v", err))
-		os.Exit(1)
 	}
 }

--- a/cmd/cernopendata-client/main_test.go
+++ b/cmd/cernopendata-client/main_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cernopendata/cernopendata-client-go/internal/downloader"
+	"github.com/cernopendata/cernopendata-client-go/internal/filemetadata"
+)
+
+func executeArgs(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := newRootCommand()
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestCommandValidationReturnsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "filter requires an output value",
+			args: []string{"get-metadata", "--filter", "name=value"},
+			want: "--filter can only be used with --output-value",
+		},
+		{
+			name: "invalid file availability",
+			args: []string{"get-file-locations", "--file-availability", "tape"},
+			want: "Invalid file availability: tape",
+		},
+		{
+			name: "invalid directory output format",
+			args: []string{"list-directory", "/tmp", "--format", "yaml"},
+			want: "Invalid format: yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := executeArgs(t, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Execute() error = %v, want error containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestConflictingFlagsReturnError(t *testing.T) {
+	err := executeArgs(t, "download-files", "--expand", "--no-expand")
+	if err == nil || !strings.Contains(err.Error(), "Cannot specify both --expand and --no-expand") {
+		t.Fatalf("Execute() error = %v, want conflicting flags diagnostic", err)
+	}
+}
+
+func TestUnknownCommandReturnsErrorWithoutCobraOutput(t *testing.T) {
+	cmd := newRootCommand()
+	var cobraOutput strings.Builder
+	cmd.SetErr(&cobraOutput)
+	cmd.SetArgs([]string{"does-not-exist"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unknown command "does-not-exist"`) {
+		t.Fatalf("Execute() error = %v, want unknown command diagnostic", err)
+	}
+	if cobraOutput.Len() != 0 {
+		t.Fatalf("Cobra wrote duplicate diagnostic %q", cobraOutput.String())
+	}
+}
+
+func TestExecutePrintsOneDiagnosticAndReturnsOne(t *testing.T) {
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"does-not-exist"})
+
+	stderr := captureStderr(t, func() {
+		if got := execute(cmd); got != 1 {
+			t.Fatalf("execute() = %d, want 1", got)
+		}
+	})
+
+	if got := strings.Count(stderr, "==> ERROR:"); got != 1 {
+		t.Fatalf("diagnostic count = %d, want 1; stderr = %q", got, stderr)
+	}
+	if !strings.Contains(stderr, `Error: unknown command "does-not-exist"`) {
+		t.Fatalf("stderr = %q, want existing-style unknown command diagnostic", stderr)
+	}
+}
+
+func TestCompletionErrorsAreReturned(t *testing.T) {
+	t.Run("missing shell", func(t *testing.T) {
+		err := executeArgs(t, "completion")
+		if err == nil || !strings.Contains(err.Error(), "Please specify bash or zsh") {
+			t.Fatalf("Execute() error = %v, want missing shell diagnostic", err)
+		}
+	})
+
+	t.Run("unsupported shell", func(t *testing.T) {
+		err := executeArgs(t, "completion", "fish")
+		if err == nil || !strings.Contains(err.Error(), "Unsupported shell: fish") {
+			t.Fatalf("Execute() error = %v, want unsupported shell diagnostic", err)
+		}
+	})
+
+	t.Run("generator failure", func(t *testing.T) {
+		cmd := newRootCommand()
+		cmd.SetOut(errorWriter{})
+		cmd.SetArgs([]string{"completion", "bash"})
+
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "Failed to generate bash completion") {
+			t.Fatalf("Execute() error = %v, want generator failure", err)
+		}
+	})
+}
+
+func TestDownstreamSearchFailureIsReturned(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	err := executeArgs(t, "search", "--server", server.URL, "--query-pattern", "Higgs")
+	if err == nil || !strings.Contains(err.Error(), "Search failed: server returned status 502") {
+		t.Fatalf("Execute() error = %v, want downstream search diagnostic", err)
+	}
+}
+
+func TestDownloadFailureRunsDeferredCleanup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"1","metadata":{"recid":1,"files":[{"uri":"root://example.test/data.root","size":1,"checksum":"adler32:00000001"}]}}`)
+	}))
+	defer server.Close()
+
+	fake := &failingXRootDDownloader{}
+	cmd := newDownloadFilesCommandWithXRootD(func() xrootdFileDownloader { return fake })
+	cmd.SetArgs([]string{
+		"--recid", "1",
+		"--server", server.URL,
+		"--download-engine", "xrootd",
+		"--no-expand",
+		"--output-dir", t.TempDir(),
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "1 file(s) failed to download") {
+		t.Fatalf("Execute() error = %v, want download failure", err)
+	}
+	if !fake.closed {
+		t.Fatal("XRootD downloader Close was not called after returned error")
+	}
+}
+
+func TestRootConstructorsDoNotShareFlagState(t *testing.T) {
+	first := newRootCommand()
+	first.SetArgs([]string{"search", "--filter", "name=value"})
+	if err := first.Execute(); err == nil {
+		t.Fatal("first Execute() succeeded, want filter validation error")
+	}
+
+	second := newRootCommand()
+	second.SetArgs([]string{"version"})
+	if err := second.Execute(); err != nil {
+		t.Fatalf("second Execute() error = %v, want isolated flag state", err)
+	}
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+type failingXRootDDownloader struct {
+	closed bool
+}
+
+func (d *failingXRootDDownloader) DownloadFiles(
+	context.Context,
+	[]filemetadata.File,
+	string,
+	int,
+	int,
+	bool,
+	bool,
+	bool,
+) downloader.DownloadStats {
+	return downloader.DownloadStats{TotalFiles: 1, TotalBytes: 1, FailedFiles: 1}
+}
+
+func (d *failingXRootDDownloader) Close() error {
+	d.closed = true
+	return nil
+}
+
+func captureStderr(t *testing.T, run func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = writer
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	run()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing stderr writer: %v", err)
+	}
+	os.Stderr = oldStderr
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading stderr: %v", err)
+	}
+	return string(output)
+}

--- a/cmd/cernopendata-client/search.go
+++ b/cmd/cernopendata-client/search.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"maps"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -15,10 +14,11 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/utils"
 )
 
-var searchCmd = &cobra.Command{
-	Use:   "search",
-	Short: "Search CERN Open Data records",
-	Long: `Search CERN Open Data records with flexible query options.
+func newSearchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search CERN Open Data records",
+		Long: `Search CERN Open Data records with flexible query options.
 
 Search the CERN Open Data portal using free text queries, facet filters,
 or by copying URLs directly from the web portal.
@@ -37,177 +37,170 @@ Examples:
      $ cernopendata-client search --query-pattern "title.tokens:*muon*" --output-value title
 
      $ cernopendata-client search --query-pattern "Higgs" --size -1`,
-	Run: func(cmd *cobra.Command, args []string) {
-		query, _ := cmd.Flags().GetString("query")
-		queryPattern, _ := cmd.Flags().GetString("query-pattern")
-		queryFacets, _ := cmd.Flags().GetStringArray("query-facet")
-		outputValue, _ := cmd.Flags().GetString("output-value")
-		filterStr, _ := cmd.Flags().GetString("filter")
-		outputFormat, _ := cmd.Flags().GetString("format")
-		server, _ := cmd.Flags().GetString("server")
-		page, _ := cmd.Flags().GetInt("page")
-		size, _ := cmd.Flags().GetInt("size")
-		sort, _ := cmd.Flags().GetString("sort")
-		listFacets, _ := cmd.Flags().GetBool("list-facets")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query, _ := cmd.Flags().GetString("query")
+			queryPattern, _ := cmd.Flags().GetString("query-pattern")
+			queryFacets, _ := cmd.Flags().GetStringArray("query-facet")
+			outputValue, _ := cmd.Flags().GetString("output-value")
+			filterStr, _ := cmd.Flags().GetString("filter")
+			outputFormat, _ := cmd.Flags().GetString("format")
+			server, _ := cmd.Flags().GetString("server")
+			page, _ := cmd.Flags().GetInt("page")
+			size, _ := cmd.Flags().GetInt("size")
+			sort, _ := cmd.Flags().GetString("sort")
+			listFacets, _ := cmd.Flags().GetBool("list-facets")
 
-		if server == "" {
-			server = config.ServerHTTPURI
-		}
-
-		client := searcher.NewClient(server)
-
-		// Handle --list-facets
-		if listFacets {
-			facets, err := client.GetFacetsContext(cmd.Context())
-			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to fetch facets: %v", err))
-				os.Exit(1)
+			if server == "" {
+				server = config.ServerHTTPURI
 			}
 
-			printer.DisplayMessage(printer.Info, "Available facets for --query-facet:\n")
-			for name, agg := range facets {
-				if len(agg.Buckets) == 0 {
-					continue
+			client := searcher.NewClient(server)
+
+			// Handle --list-facets
+			if listFacets {
+				facets, err := client.GetFacetsContext(cmd.Context())
+				if err != nil {
+					return commandErrorf("Failed to fetch facets: %w", err)
 				}
-				printer.DisplayOutput(fmt.Sprintf("%s:", name))
-				for _, bucket := range agg.Buckets {
-					keyStr := fmt.Sprintf("%v", bucket.Key)
-					printer.DisplayOutput(fmt.Sprintf("  - %s (%d)", keyStr, bucket.DocCount))
+
+				printer.DisplayMessage(printer.Info, "Available facets for --query-facet:\n")
+				for name, agg := range facets {
+					if len(agg.Buckets) == 0 {
+						continue
+					}
+					printer.DisplayOutput(fmt.Sprintf("%s:", name))
+					for _, bucket := range agg.Buckets {
+						keyStr := fmt.Sprintf("%v", bucket.Key)
+						printer.DisplayOutput(fmt.Sprintf("  - %s (%d)", keyStr, bucket.DocCount))
+					}
+					printer.DisplayOutput("")
 				}
-				printer.DisplayOutput("")
+				return nil
 			}
-			return
-		}
 
-		if filterStr != "" && outputValue == "" {
-			printer.DisplayMessage(printer.Error, "--filter can only be used with --output-value")
-			os.Exit(1)
-		}
+			if filterStr != "" && outputValue == "" {
+				return fmt.Errorf("--filter can only be used with --output-value")
+			}
 
-		// Build query from parameters
-		facetsMap := make(map[string]string)
+			// Build query from parameters
+			facetsMap := make(map[string]string)
 
-		// Parse --query URL/query string if provided
-		if query != "" {
-			parsedQuery, err := utils.ParseQueryFromURL(query)
+			// Parse --query URL/query string if provided
+			if query != "" {
+				parsedQuery, err := utils.ParseQueryFromURL(query)
+				if err != nil {
+					return commandErrorf("Failed to parse query: %w", err)
+				}
+				// Use parsed values as defaults
+				if queryPattern == "" && parsedQuery.Q != "" {
+					queryPattern = parsedQuery.Q
+				}
+				maps.Copy(facetsMap, parsedQuery.Facets)
+				if parsedQuery.Page != nil && !cmd.Flags().Changed("page") {
+					page = *parsedQuery.Page
+				}
+				if parsedQuery.Size != nil && !cmd.Flags().Changed("size") {
+					size = *parsedQuery.Size
+				}
+				if parsedQuery.Sort != "" && sort == "" {
+					sort = parsedQuery.Sort
+				}
+			}
+
+			// Parse --query-facet flags (override parsed facets)
+			for _, qf := range queryFacets {
+				parts := strings.SplitN(qf, "=", 2)
+				if len(parts) != 2 {
+					return commandErrorf("Invalid facet format: %s (expected key=value)", qf)
+				}
+				facetsMap[parts[0]] = parts[1]
+			}
+
+			var searchResp *searcher.SearchResponse
+			var err error
+
+			// Handle --size -1 for fetching all results
+			if size == -1 {
+				searchResp, err = client.SearchAllRecordsContext(cmd.Context(), queryPattern, facetsMap, sort)
+			} else {
+				searchResp, err = client.SearchRecordsContext(cmd.Context(), queryPattern, facetsMap, page, size, sort)
+			}
+
 			if err != nil {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to parse query: %v", err))
-				os.Exit(1)
+				return commandErrorf("Search failed: %w", err)
 			}
-			// Use parsed values as defaults
-			if queryPattern == "" && parsedQuery.Q != "" {
-				queryPattern = parsedQuery.Q
+
+			if searchResp.Hits.Total == 0 {
+				printer.DisplayMessage(printer.Info, "No records found.")
+				return nil
 			}
-			maps.Copy(facetsMap, parsedQuery.Facets)
-			if parsedQuery.Page != nil && !cmd.Flags().Changed("page") {
-				page = *parsedQuery.Page
+
+			var filters []string
+			if filterStr != "" {
+				filters = []string{filterStr}
 			}
-			if parsedQuery.Size != nil && !cmd.Flags().Changed("size") {
-				size = *parsedQuery.Size
-			}
-			if parsedQuery.Sort != "" && sort == "" {
-				sort = parsedQuery.Sort
-			}
-		}
 
-		// Parse --query-facet flags (override parsed facets)
-		for _, qf := range queryFacets {
-			parts := strings.SplitN(qf, "=", 2)
-			if len(parts) != 2 {
-				printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid facet format: %s (expected key=value)", qf))
-				os.Exit(1)
-			}
-			facetsMap[parts[0]] = parts[1]
-		}
-
-		var searchResp *searcher.SearchResponse
-		var err error
-
-		// Handle --size -1 for fetching all results
-		if size == -1 {
-			searchResp, err = client.SearchAllRecordsContext(cmd.Context(), queryPattern, facetsMap, sort)
-		} else {
-			searchResp, err = client.SearchRecordsContext(cmd.Context(), queryPattern, facetsMap, page, size, sort)
-		}
-
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Search failed: %v", err))
-			os.Exit(1)
-		}
-
-		if searchResp.Hits.Total == 0 {
-			printer.DisplayMessage(printer.Info, "No records found.")
-			return
-		}
-
-		var filters []string
-		if filterStr != "" {
-			filters = []string{filterStr}
-		}
-
-		// Output handling
-		if outputValue == "" {
-			// Default: print record titles
-			for _, hit := range searchResp.Hits.Hits {
-				if title, ok := hit.Metadata["title"].(string); ok {
-					printer.DisplayOutput(title)
+			// Output handling
+			if outputValue == "" {
+				// Default: print record titles
+				for _, hit := range searchResp.Hits.Hits {
+					if title, ok := hit.Metadata["title"].(string); ok {
+						printer.DisplayOutput(title)
+					} else {
+						printer.DisplayOutput(fmt.Sprintf("Record %s", hit.ID))
+					}
+				}
+				// Show total count if there are more results
+				displayed := len(searchResp.Hits.Hits)
+				if searchResp.Hits.Total > displayed {
+					printer.DisplayMessage(printer.Info, fmt.Sprintf("\nShowing %d of %d total records. Use --size -1 to fetch all.", displayed, searchResp.Hits.Total))
 				} else {
-					printer.DisplayOutput(fmt.Sprintf("Record %s", hit.ID))
+					printer.DisplayMessage(printer.Info, fmt.Sprintf("\nTotal: %d records", searchResp.Hits.Total))
 				}
-			}
-			// Show total count if there are more results
-			displayed := len(searchResp.Hits.Hits)
-			if searchResp.Hits.Total > displayed {
-				printer.DisplayMessage(printer.Info, fmt.Sprintf("\nShowing %d of %d total records. Use --size -1 to fetch all.", displayed, searchResp.Hits.Total))
 			} else {
-				printer.DisplayMessage(printer.Info, fmt.Sprintf("\nTotal: %d records", searchResp.Hits.Total))
-			}
-		} else {
-			// Extract specific field from each record
-			var results []any
-			for _, hit := range searchResp.Hits.Hits {
-				value, err := metadater.ExtractNestedField(hit.Metadata, outputValue)
-				if err == nil && value != nil {
-					results = append(results, value)
+				// Extract specific field from each record
+				var results []any
+				for _, hit := range searchResp.Hits.Hits {
+					value, err := metadater.ExtractNestedField(hit.Metadata, outputValue)
+					if err == nil && value != nil {
+						results = append(results, value)
+					}
 				}
-			}
 
-			if len(filters) > 0 {
-				filtered, err := metadater.FilterArray(results, filters)
-				if err != nil {
-					printer.DisplayMessage(printer.Error, fmt.Sprintf("Filter error: %v", err))
-					os.Exit(1)
+				if len(filters) > 0 {
+					filtered, err := metadater.FilterArray(results, filters)
+					if err != nil {
+						return commandErrorf("Filter error: %w", err)
+					}
+					results = filtered
 				}
-				results = filtered
-			}
 
-			if outputFormat == "json" {
-				output, err := metadater.FormatOutput(results, outputFormat)
-				if err != nil {
-					printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to format output: %v", err))
-					os.Exit(1)
-				}
-				printer.DisplayOutput(output)
-			} else {
-				// Pretty format: print each result on a line
-				for _, result := range results {
-					printer.DisplayOutput(fmt.Sprintf("%v", result))
+				if outputFormat == "json" {
+					output, err := metadater.FormatOutput(results, outputFormat)
+					if err != nil {
+						return commandErrorf("Failed to format output: %w", err)
+					}
+					printer.DisplayOutput(output)
+				} else {
+					// Pretty format: print each result on a line
+					for _, result := range results {
+						printer.DisplayOutput(fmt.Sprintf("%v", result))
+					}
 				}
 			}
-		}
-	},
-}
-
-func init() {
-	searchCmd.Flags().StringP("query", "q", "", "Full URL or query string from CERN Open Data portal")
-	searchCmd.Flags().String("query-pattern", "", "Free text search pattern (see https://opendata.cern.ch/docs/cod-search-tips)")
-	searchCmd.Flags().StringArrayP("query-facet", "f", []string{}, "Facet filter in key=value format (can be repeated)")
-	searchCmd.Flags().StringP("output-value", "o", "", "Extract specific metadata field from results")
-	searchCmd.Flags().String("filter", "", "Filter array results (requires --output-value)")
-	searchCmd.Flags().StringP("format", "m", "pretty", "Output format (pretty|json)")
-	searchCmd.Flags().StringP("server", "s", "", "CERN Open Data server URL [default=http://opendata.cern.ch]")
-	searchCmd.Flags().IntP("page", "p", 1, "Page number")
-	searchCmd.Flags().Int("size", 10, "Page size (-1 for all results)")
-	searchCmd.Flags().String("sort", "", "Sort order")
-	searchCmd.Flags().Bool("list-facets", false, "List available facets for filtering")
+			return nil
+		},
+	}
+	cmd.Flags().StringP("query", "q", "", "Full URL or query string from CERN Open Data portal")
+	cmd.Flags().String("query-pattern", "", "Free text search pattern (see https://opendata.cern.ch/docs/cod-search-tips)")
+	cmd.Flags().StringArrayP("query-facet", "f", []string{}, "Facet filter in key=value format (can be repeated)")
+	cmd.Flags().StringP("output-value", "o", "", "Extract specific metadata field from results")
+	cmd.Flags().String("filter", "", "Filter array results (requires --output-value)")
+	cmd.Flags().StringP("format", "m", "pretty", "Output format (pretty|json)")
+	cmd.Flags().StringP("server", "s", "", "CERN Open Data server URL [default=http://opendata.cern.ch]")
+	cmd.Flags().IntP("page", "p", 1, "Page number")
+	cmd.Flags().Int("size", 10, "Page size (-1 for all results)")
+	cmd.Flags().String("sort", "", "Sort order")
+	cmd.Flags().Bool("list-facets", false, "List available facets for filtering")
+	return cmd
 }

--- a/cmd/cernopendata-client/update.go
+++ b/cmd/cernopendata-client/update.go
@@ -12,28 +12,27 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/version"
 )
 
-var checkOnly bool
-
-var updateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Check for and install updates",
-	Long: `Check for available updates and optionally install them.
+func newUpdateCommand() *cobra.Command {
+	var checkOnly bool
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Check for and install updates",
+		Long: `Check for available updates and optionally install them.
 
 By default, this command will download and install the latest version.
 Use --check to only check for updates without installing.
 
 If the binary was installed via Homebrew, the command will suggest using
 'brew upgrade' instead of performing a self-update.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return runUpdate()
-	},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUpdate(checkOnly)
+		},
+	}
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only check for updates, don't install")
+	return cmd
 }
 
-func init() {
-	updateCmd.Flags().BoolVar(&checkOnly, "check", false, "Only check for updates, don't install")
-}
-
-func runUpdate() error {
+func runUpdate(checkOnly bool) error {
 	currentVersion := version.Version
 
 	printer.DisplayMessage(printer.Info, fmt.Sprintf("Current version: %s", currentVersion))

--- a/cmd/cernopendata-client/verify_files.go
+++ b/cmd/cernopendata-client/verify_files.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,10 +13,11 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/verifier"
 )
 
-var verifyFilesCmd = &cobra.Command{
-	Use:   "verify-files",
-	Short: "Verify local files against expected checksums and sizes",
-	Long: `Verify downloaded data file integrity.
+func newVerifyFilesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify-files",
+		Short: "Verify local files against expected checksums and sizes",
+		Long: `Verify downloaded data file integrity.
 
 Select a CERN Open Data bibliographic record by a record ID, a
 DOI, or a title and verify integrity of downloaded data files
@@ -26,101 +26,94 @@ belonging to this record.
 Examples:
 
      $ cernopendata-client verify-files --recid 5500`,
-	Run: func(cmd *cobra.Command, args []string) {
-		recid, err := cmd.Flags().GetInt("recid")
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Invalid recid: %v", err))
-			os.Exit(1)
-		}
-		doi, _ := cmd.Flags().GetString("doi")
-		title, _ := cmd.Flags().GetString("title")
-		inputDir, _ := cmd.Flags().GetString("input-dir")
-		filterName, _ := cmd.Flags().GetString("filter-name")
-		filterRegexp, _ := cmd.Flags().GetString("filter-regexp")
-		server, _ := cmd.Flags().GetString("server")
-
-		if server == "" {
-			server = config.ServerHTTPURI
-		}
-
-		parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to find record: %v", err))
-			os.Exit(1)
-		}
-
-		if inputDir == "" {
-			inputDir = fmt.Sprintf("%d", parsedRecid)
-		}
-
-		client := searcher.NewClient(server)
-		record, err := client.GetRecord(parsedRecid)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to get record: %v", err))
-			os.Exit(1)
-		}
-
-		files, err := client.GetFilesList(record, "http", false)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Failed to get files list: %v", err))
-			os.Exit(1)
-		}
-
-		fileList := files
-
-		if filterName != "" {
-			nameFilters := strings.Split(filterName, ",")
-			for i, filter := range nameFilters {
-				nameFilters[i] = strings.TrimSpace(filter)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			recid, err := cmd.Flags().GetInt("recid")
+			if err != nil {
+				return commandErrorf("Invalid recid: %w", err)
 			}
-			fileList = downloader.FilterFilesByMultipleNames(fileList, nameFilters)
-		}
+			doi, _ := cmd.Flags().GetString("doi")
+			title, _ := cmd.Flags().GetString("title")
+			inputDir, _ := cmd.Flags().GetString("input-dir")
+			filterName, _ := cmd.Flags().GetString("filter-name")
+			filterRegexp, _ := cmd.Flags().GetString("filter-regexp")
+			server, _ := cmd.Flags().GetString("server")
 
-		if filterRegexp != "" {
-			fileList = downloader.FilterFilesByRegex(fileList, filterRegexp)
-		}
+			if server == "" {
+				server = config.ServerHTTPURI
+			}
 
-		if len(fileList) == 0 {
-			printer.DisplayMessage(printer.Error, "No files matching filters")
-			os.Exit(1)
-		}
+			parsedRecid, err := searcher.GetRecid(server, doi, title, recid)
+			if err != nil {
+				return commandErrorf("Failed to find record: %w", err)
+			}
 
-		verifier := verifier.NewVerifier()
-		stats, err := verifier.VerifyFiles(inputDir, fileList)
-		if err != nil {
-			printer.DisplayMessage(printer.Error, fmt.Sprintf("Verification failed: %v", err))
-			os.Exit(1)
-		}
+			if inputDir == "" {
+				inputDir = fmt.Sprintf("%d", parsedRecid)
+			}
 
-		printer.DisplayMessage(printer.Info, fmt.Sprintf("Verifying number of files for record %d...", parsedRecid))
-		printer.DisplayMessage(printer.Note, fmt.Sprintf("Expected %d, found %d", len(fileList), stats.VerifiedFiles+stats.SizeFailed+stats.ChecksumFailed+stats.MissingFiles))
+			client := searcher.NewClient(server)
+			record, err := client.GetRecord(parsedRecid)
+			if err != nil {
+				return commandErrorf("Failed to get record: %w", err)
+			}
 
-		if len(fileList) != (stats.VerifiedFiles + stats.SizeFailed + stats.ChecksumFailed + stats.MissingFiles) {
-			printer.DisplayMessage(printer.Error, "File count does not match.")
-			os.Exit(1)
-		}
+			files, err := client.GetFilesList(record, "http", false)
+			if err != nil {
+				return commandErrorf("Failed to get files list: %w", err)
+			}
 
-		printer.DisplayMessage(printer.Info, "\nVerification summary:")
-		printer.DisplayMessage(printer.Note, fmt.Sprintf("  Total files:     %d", stats.TotalFiles))
-		printer.DisplayMessage(printer.Note, fmt.Sprintf("  Verified:        %d", stats.VerifiedFiles))
-		printer.DisplayMessage(printer.Note, fmt.Sprintf("  Size errors:     %d", stats.SizeFailed))
-		printer.DisplayMessage(printer.Note, fmt.Sprintf("  Checksum errors: %d", stats.ChecksumFailed))
-		printer.DisplayMessage(printer.Note, fmt.Sprintf("  Missing files:   %d", stats.MissingFiles))
+			fileList := files
 
-		if stats.SizeFailed > 0 || stats.ChecksumFailed > 0 || stats.MissingFiles > 0 {
-			os.Exit(1)
-		}
+			if filterName != "" {
+				nameFilters := strings.Split(filterName, ",")
+				for i, filter := range nameFilters {
+					nameFilters[i] = strings.TrimSpace(filter)
+				}
+				fileList = downloader.FilterFilesByMultipleNames(fileList, nameFilters)
+			}
 
-		printer.DisplayMessage(printer.Info, "Success!")
-	},
-}
+			if filterRegexp != "" {
+				fileList = downloader.FilterFilesByRegex(fileList, filterRegexp)
+			}
 
-func init() {
-	verifyFilesCmd.Flags().IntP("recid", "r", 0, "Record ID (exact match)")
-	verifyFilesCmd.Flags().StringP("doi", "d", "", "Digital Object Identifier (exact match)")
-	verifyFilesCmd.Flags().StringP("title", "t", "", "Record title (exact match, no wildcards)")
-	verifyFilesCmd.Flags().StringP("input-dir", "i", "", "Input directory containing files to verify")
-	verifyFilesCmd.Flags().StringP("filter-name", "n", "", "Verify files matching exactly the file name")
-	verifyFilesCmd.Flags().StringP("filter-regexp", "e", "", "Verify files matching the regular expression")
-	verifyFilesCmd.Flags().StringP("server", "s", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
+			if len(fileList) == 0 {
+				return commandErrorf("No files matching filters")
+			}
+
+			verifier := verifier.NewVerifier()
+			stats, err := verifier.VerifyFiles(inputDir, fileList)
+			if err != nil {
+				return commandErrorf("Verification failed: %w", err)
+			}
+
+			printer.DisplayMessage(printer.Info, fmt.Sprintf("Verifying number of files for record %d...", parsedRecid))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("Expected %d, found %d", len(fileList), stats.VerifiedFiles+stats.SizeFailed+stats.ChecksumFailed+stats.MissingFiles))
+
+			if len(fileList) != (stats.VerifiedFiles + stats.SizeFailed + stats.ChecksumFailed + stats.MissingFiles) {
+				return commandErrorf("File count does not match")
+			}
+
+			printer.DisplayMessage(printer.Info, "\nVerification summary:")
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("  Total files:     %d", stats.TotalFiles))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("  Verified:        %d", stats.VerifiedFiles))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("  Size errors:     %d", stats.SizeFailed))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("  Checksum errors: %d", stats.ChecksumFailed))
+			printer.DisplayMessage(printer.Note, fmt.Sprintf("  Missing files:   %d", stats.MissingFiles))
+
+			if stats.SizeFailed > 0 || stats.ChecksumFailed > 0 || stats.MissingFiles > 0 {
+				return commandErrorf("Some files failed verification")
+			}
+
+			printer.DisplayMessage(printer.Info, "Success!")
+			return nil
+		},
+	}
+	cmd.Flags().IntP("recid", "r", 0, "Record ID (exact match)")
+	cmd.Flags().StringP("doi", "d", "", "Digital Object Identifier (exact match)")
+	cmd.Flags().StringP("title", "t", "", "Record title (exact match, no wildcards)")
+	cmd.Flags().StringP("input-dir", "i", "", "Input directory containing files to verify")
+	cmd.Flags().StringP("filter-name", "n", "", "Verify files matching exactly the file name")
+	cmd.Flags().StringP("filter-regexp", "e", "", "Verify files matching the regular expression")
+	cmd.Flags().StringP("server", "s", "", "Which CERN Open Data server to query? [default=http://opendata.cern.ch]")
+	return cmd
 }

--- a/cmd/cernopendata-client/version.go
+++ b/cmd/cernopendata-client/version.go
@@ -7,10 +7,12 @@ import (
 	"github.com/cernopendata/cernopendata-client-go/internal/version"
 )
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Return version",
-	Run: func(cmd *cobra.Command, args []string) {
-		printer.DisplayOutput(version.Version)
-	},
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Return version",
+		Run: func(cmd *cobra.Command, args []string) {
+			printer.DisplayOutput(version.Version)
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- construct a fresh root and subcommands for every execution
- return command failures through Cobra while keeping `os.Exit` only in `main`
- silence duplicate Cobra output and preserve a single existing-style diagnostic
- cover validation, flag conflicts, unknown commands, completion failures, downstream failures, and deferred XRootD cleanup

## Local validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `make build-all`
- `PATH=/Users/clange/go/bin:$PATH prek run --all-files`
- `git diff --check`