### PR TITLE
test: make live integration outcomes explicit

### DIFF
--- a/cmd/cernopendata-client/integration_test.go
+++ b/cmd/cernopendata-client/integration_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/adler32"
 	"net/http"
@@ -22,6 +23,168 @@ const (
 	testRecID            = "3005"
 	testUnavailableRecID = "8886"
 )
+
+type liveService string
+
+const (
+	liveCERNHTTP liveService = "CERN HTTP"
+	liveGitHub   liveService = "GitHub"
+	liveXRootD   liveService = "XRootD"
+)
+
+func environmentalFailureReason(service liveService, err, contextErr error, output string) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(contextErr, context.DeadlineExceeded) {
+		return "request timed out", true
+	}
+
+	details := strings.ToLower(err.Error() + "\n" + output)
+	transportFailures := []struct {
+		pattern string
+		reason  string
+	}{
+		{"context deadline exceeded", "request timed out"},
+		{"i/o timeout", "request timed out"},
+		{"operation timed out", "request timed out"},
+		{"no such host", "DNS lookup failed"},
+		{"temporary failure in name resolution", "DNS lookup failed"},
+		{"server misbehaving", "DNS lookup failed"},
+		{"tls handshake timeout", "TLS handshake failed"},
+		{"remote error: tls", "TLS handshake failed"},
+		{"x509:", "TLS certificate validation failed"},
+		{"certificate signed by unknown authority", "TLS certificate validation failed"},
+		{"connection refused", "connection failed"},
+		{"connection reset by peer", "connection failed"},
+		{"network is unreachable", "connection failed"},
+		{"no route to host", "connection failed"},
+		{"connection timed out", "connection failed"},
+	}
+	for _, failure := range transportFailures {
+		if strings.Contains(details, failure.pattern) {
+			return failure.reason, true
+		}
+	}
+
+	switch service {
+	case liveGitHub:
+		for _, status := range []string{"github api returned status 403", "github api returned status 429"} {
+			if strings.Contains(details, status) {
+				return status, true
+			}
+		}
+	case liveCERNHTTP:
+		for _, status := range []string{"429", "502", "503", "504"} {
+			if strings.Contains(details, "server returned status "+status) ||
+				strings.Contains(details, "server error: "+status) ||
+				strings.Contains(details, "server returned "+status+":") {
+				return "CERN HTTP status " + status, true
+			}
+		}
+	case liveXRootD:
+		for _, pattern := range []string{
+			"failed to create xrootd client",
+			"could not connect to xrootd server",
+			"xrootd: failed to connect",
+			"xrootd: connection closed",
+			"xrootd: transport error",
+			"xrootd: connection: wrong handshake",
+		} {
+			if strings.Contains(details, pattern) {
+				return "XRootD transport failed", true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func assertLiveCommandSuccess(
+	t *testing.T,
+	service liveService,
+	err, contextErr error,
+	output string,
+	description string,
+) string {
+	t.Helper()
+	if err != nil {
+		if reason, recognized := environmentalFailureReason(service, err, contextErr, output); recognized {
+			t.Skipf("Skipping %s after recognized %s environmental failure (%s): %v\nOutput: %s", description, service, reason, err, output)
+		}
+		t.Fatalf("%s failed unexpectedly: %v\nOutput: %s", description, err, output)
+	}
+	if strings.TrimSpace(output) == "" {
+		t.Fatalf("%s returned empty output", description)
+	}
+	return output
+}
+
+func assertCommandErrorContains(
+	t *testing.T,
+	err error,
+	output string,
+	description string,
+	want ...string,
+) string {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Expected %s to fail, but it succeeded\nOutput: %s", description, output)
+	}
+	if strings.TrimSpace(output) == "" {
+		t.Fatalf("%s failed without the expected product diagnostic: %v", description, err)
+	}
+	for _, fragment := range want {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("%s returned the wrong product diagnostic; expected %q\nOutput: %s", description, fragment, output)
+		}
+	}
+	return output
+}
+
+func TestEnvironmentalFailureReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		service    liveService
+		err        error
+		contextErr error
+		output     string
+		want       bool
+	}{
+		{name: "context timeout", service: liveCERNHTTP, err: errors.New("signal: killed"), contextErr: context.DeadlineExceeded, want: true},
+		{name: "reported timeout", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "dial tcp: i/o timeout", want: true},
+		{name: "DNS", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "lookup opendata.cern.ch: no such host", want: true},
+		{name: "TLS", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "tls handshake timeout", want: true},
+		{name: "connect", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "dial tcp: connection refused", want: true},
+		{name: "XRootD transport", service: liveXRootD, err: errors.New("exit status 1"), output: "xrootd: transport error: socket closed", want: true},
+		{name: "XRootD connect", service: liveXRootD, err: errors.New("exit status 1"), output: `xrdio: could not connect to xrootd server "eospublic.cern.ch:1094"`, want: true},
+		{name: "GitHub forbidden", service: liveGitHub, err: errors.New("exit status 1"), output: "GitHub API returned status 403", want: true},
+		{name: "GitHub rate limit", service: liveGitHub, err: errors.New("exit status 1"), output: "GitHub API returned status 429", want: true},
+		{name: "CERN rate limit", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "server returned status 429 for search", want: true},
+		{name: "CERN bad gateway", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "server returned status 502 for record 3005", want: true},
+		{name: "CERN unavailable", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "server returned status 503 for search", want: true},
+		{name: "CERN binary unavailable", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "Server error: 503", want: true},
+		{name: "CERN download unavailable", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "server returned 503: service unavailable", want: true},
+		{name: "CERN gateway timeout", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "server returned status 504 for search", want: true},
+		{name: "success cannot be environmental", service: liveCERNHTTP, output: "server returned status 503 for search", want: false},
+		{name: "unexpected CERN status", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "server returned status 500 for search", want: false},
+		{name: "unbounded CERN status", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "downloaded 503 bytes before failure", want: false},
+		{name: "GitHub status on CERN request", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "GitHub API returned status 403", want: false},
+		{name: "CERN status on GitHub request", service: liveGitHub, err: errors.New("exit status 1"), output: "server returned status 503 for search", want: false},
+		{name: "XRootD missing fixture", service: liveXRootD, err: errors.New("exit status 1"), output: "xrootd: error 3011: no such file or directory", want: false},
+		{name: "unexpected command error", service: liveCERNHTTP, err: errors.New("exit status 1"), output: "failed to parse output", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := environmentalFailureReason(tt.service, tt.err, tt.contextErr, tt.output)
+			if got != tt.want {
+				t.Fatalf("environmentalFailureReason() recognized = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func getBinaryPath() string {
 	_, callerFile, _, _ := runtime.Caller(0)
@@ -45,25 +208,13 @@ func runIntegrationCommand(t *testing.T, args ...string) (string, error) {
 func assertCommandSuccess(t *testing.T, args ...string) string {
 	t.Helper()
 	output, err := runIntegrationCommand(t, args...)
-	if err != nil {
-		t.Fatalf("Command %v failed: %v\nOutput: %s", args, err, output)
-	}
-	if len(output) == 0 {
-		t.Errorf("Command %v returned empty output", args)
-	}
-	return string(output)
+	return assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, output, fmt.Sprintf("command %v", args))
 }
 
-func assertCommandError(t *testing.T, args ...string) string {
+func assertCERNCommandError(t *testing.T, want string, args ...string) string {
 	t.Helper()
 	output, err := runIntegrationCommand(t, args...)
-	if err == nil {
-		t.Fatalf("Expected command %v to fail, but it succeeded\nOutput: %s", args, output)
-	}
-	if len(output) == 0 {
-		t.Errorf("Command %v failed as expected but returned empty output (expected error message)", args)
-	}
-	return string(output)
+	return assertCommandErrorContains(t, err, output, fmt.Sprintf("command %v", args), want)
 }
 
 func TestIntegrationGetMetadata(t *testing.T) {
@@ -82,17 +233,11 @@ func TestIntegrationGetMetadataByTitle(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--title", "Configuration file for LHE step HIG-Summer11pLHE-00114_1_cfg.py")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-metadata by title: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-metadata by title")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-metadata by title")
 }
 
 func TestIntegrationGetMetadataByTitleWrong(t *testing.T) {
-	assertCommandError(t, "get-metadata", "--title", "NONEXISTING_TITLE")
+	assertCERNCommandError(t, "no record found with title: NONEXISTING_TITLE", "get-metadata", "--title", "NONEXISTING_TITLE")
 }
 
 func TestIntegrationGetMetadataByAlternateDOI(t *testing.T) {
@@ -103,13 +248,7 @@ func TestIntegrationGetMetadataByAlternateDOI(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--doi", "10.7483/OPENDATA.CMS.A342.9982")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-metadata by alternate DOI: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-metadata by alternate DOI")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-metadata by alternate DOI")
 }
 
 func TestIntegrationGetMetadataOutputValueBasic(t *testing.T) {
@@ -120,11 +259,8 @@ func TestIntegrationGetMetadataOutputValueBasic(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--recid", "1", "--output-value", "system_details.global_tag")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-metadata with output-value: %v\nOutput: %s", err, string(output))
-	}
-
-	if !contains(string(output), "FT_R_42_V10A::All") {
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-metadata with output value")
+	if !contains(outputStr, "FT_R_42_V10A::All") {
 		t.Error("Expected 'FT_R_42_V10A::All' in output")
 	}
 }
@@ -137,13 +273,7 @@ func TestIntegrationGetMetadataOutputValueArray(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--recid", "1", "--output-value", "usage.links")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-metadata with array output-value: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output for array field")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-metadata with array output value")
 }
 
 func TestIntegrationGetMetadataOutputValueNested(t *testing.T) {
@@ -154,13 +284,7 @@ func TestIntegrationGetMetadataOutputValueNested(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--recid", "1", "--output-value", "usage.links.url")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-metadata with nested output-value: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output for nested field")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-metadata with nested output value")
 }
 
 func TestIntegrationGetMetadataOutputValueWrong(t *testing.T) {
@@ -171,13 +295,7 @@ func TestIntegrationGetMetadataOutputValueWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--recid", "1", "--output-value", "title.global_tag")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for wrong field, but got none")
-	}
-
-	if !contains(string(output), "Field not found") && !contains(string(output), "is not present") {
-		t.Error("Expected field not found error in output")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-metadata with an invalid nested field", "Field not found", "cannot access field global_tag on non-map type")
 }
 
 func TestIntegrationGetMetadataNoIdentifier(t *testing.T) {
@@ -188,13 +306,7 @@ func TestIntegrationGetMetadataNoIdentifier(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error when no identifier provided, but got none")
-	}
-
-	if !contains(string(output), "recid") && !contains(string(output), "doi") && !contains(string(output), "title") {
-		t.Error("Expected error message to mention required identifier")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-metadata without an identifier", "please provide recid, doi, or title")
 }
 
 func TestIntegrationGetMetadataInvalidServer(t *testing.T) {
@@ -205,13 +317,7 @@ func TestIntegrationGetMetadataInvalidServer(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--recid", testRecID, "--server", "ftp://invalid.com")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for invalid server, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for invalid server")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-metadata with an invalid server scheme", "Failed to get metadata", "unsupported protocol scheme \"ftp\"")
 }
 
 func TestIntegrationGetMetadataFilterWithoutOutputValue(t *testing.T) {
@@ -222,13 +328,7 @@ func TestIntegrationGetMetadataFilterWithoutOutputValue(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-metadata", "--recid", "1", "--filter", "foo=bar")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error when using --filter without --output-value")
-	}
-
-	if !contains(string(output), "--filter") || !contains(string(output), "--output-value") {
-		t.Error("Expected message about --filter requiring --output-value")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-metadata filter without output value", "--filter can only be used with --output-value")
 }
 
 func TestIntegrationGetFileLocations(t *testing.T) {
@@ -247,15 +347,7 @@ func TestIntegrationGetFileLocationsVerbose(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testRecID, "--verbose")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-file-locations with verbose: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-file-locations verbose")
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verbose get-file-locations")
 	if len(outputStr) < 10 {
 		t.Error("Expected verbose output to have more content")
 	}
@@ -269,13 +361,7 @@ func TestIntegrationGetFileLocationsByRecidWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", "0")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for invalid recid 0, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for invalid recid")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-file-locations with recid zero", "please provide recid, doi, or title")
 }
 
 func TestIntegrationGetFileLocationsByDOI(t *testing.T) {
@@ -286,13 +372,7 @@ func TestIntegrationGetFileLocationsByDOI(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--doi", "10.7483/OPENDATA.CMS.A342.9982")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-file-locations by DOI: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-file-locations by DOI")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations by DOI")
 }
 
 func TestIntegrationGetFileLocationsByDOIWrong(t *testing.T) {
@@ -303,13 +383,7 @@ func TestIntegrationGetFileLocationsByDOIWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--doi", "NONEXISTING")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for non-existing DOI, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for non-existing DOI")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-file-locations with a nonexistent DOI", "no record found with doi: NONEXISTING")
 }
 
 func TestIntegrationGetFileLocationsByTitle(t *testing.T) {
@@ -320,13 +394,7 @@ func TestIntegrationGetFileLocationsByTitle(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--title", "Configuration file for LHE step HIG-Summer11pLHE-00114_1_cfg.py")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-file-locations by title: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-file-locations by title")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations by title")
 }
 
 func TestIntegrationGetFileLocationsByTitleWrong(t *testing.T) {
@@ -337,13 +405,7 @@ func TestIntegrationGetFileLocationsByTitleWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--title", "NONEXISTING_TITLE")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for non-existing title, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for non-existing title")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-file-locations with a nonexistent title", "no record found with title: NONEXISTING_TITLE")
 }
 
 func TestIntegrationGetFileLocationsHTTP(t *testing.T) {
@@ -354,13 +416,7 @@ func TestIntegrationGetFileLocationsHTTP(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testRecID, "--protocol", "http")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-file-locations with http: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-file-locations with http")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations with HTTP URLs")
 }
 
 func TestIntegrationGetFileLocationsHTTPS(t *testing.T) {
@@ -371,13 +427,7 @@ func TestIntegrationGetFileLocationsHTTPS(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testRecID, "--protocol", "https")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-file-locations with https: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-file-locations with https")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations with HTTPS URLs")
 }
 
 func TestIntegrationGetFileLocationsExpand(t *testing.T) {
@@ -388,13 +438,7 @@ func TestIntegrationGetFileLocationsExpand(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testRecID, "--expand")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run get-file-locations with expand: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from get-file-locations with expand")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "expanded get-file-locations")
 }
 
 func TestIntegrationGetFileLocationsNoIdentifier(t *testing.T) {
@@ -405,13 +449,7 @@ func TestIntegrationGetFileLocationsNoIdentifier(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error when no identifier provided, but got none")
-	}
-
-	if !contains(string(output), "recid") && !contains(string(output), "doi") && !contains(string(output), "title") {
-		t.Error("Expected error message to mention required identifier")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-file-locations without an identifier", "please provide recid, doi, or title")
 }
 
 func TestIntegrationGetFileLocationsInvalidServer(t *testing.T) {
@@ -422,13 +460,7 @@ func TestIntegrationGetFileLocationsInvalidServer(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testRecID, "--server", "ftp://invalid.com")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for invalid server, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for invalid server")
-	}
+	assertCommandErrorContains(t, err, string(output), "get-file-locations with an invalid server scheme", "Failed to get record", "unsupported protocol scheme \"ftp\"")
 }
 
 func TestIntegrationVersion(t *testing.T) {
@@ -445,18 +477,12 @@ func TestIntegrationDownloadFiles(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.txt", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: download-files failed (expected if no .txt files): %v\nOutput: %s", err, string(output))
-		return
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files with an unmatched name filter", "No files matching filters")
 
-	files, err := os.ReadDir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to read temp directory: %v", err)
-	}
+	files := mustReadDir(t, tmpDir)
 
-	if len(files) == 0 {
-		t.Log("No files downloaded (expected if no .txt files in record)")
+	if len(files) != 0 {
+		t.Fatalf("Expected no files for the unmatched filter, got %d", len(files))
 	}
 }
 
@@ -470,36 +496,17 @@ func TestIntegrationDownloadFilesByDOI(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--doi", "10.7483/OPENDATA.CMS.W26R.J96R", "--filter-name", "readme.txt", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: download by DOI failed: %v\nOutput: %s", err, string(output))
-		return
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files by DOI")
 
-	files, err := os.ReadDir(tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to read temp directory: %v", err)
-	}
+	files := mustReadDir(t, tmpDir)
 
-	if len(files) == 0 {
-		t.Log("No files downloaded from DOI")
+	if len(files) != 1 || files[0].Name() != "readme.txt" {
+		t.Fatalf("Expected exactly readme.txt from DOI fixture, got %v", files)
 	}
 }
 
 func TestIntegrationDownloadFilesByDOIWrong(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	// #nosec G204
-	cmd := exec.Command(getBinaryPath(), "download-files", "--doi", "NONEXISTING")
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for non-existing DOI, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for non-existing DOI")
-	}
+	assertCERNCommandError(t, "no record found with doi: NONEXISTING", "download-files", "--doi", "NONEXISTING")
 }
 
 func TestIntegrationListDirectory(t *testing.T) {
@@ -513,14 +520,7 @@ func TestIntegrationListDirectory(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "list-directory", "/eos/opendata/cms")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: list-directory failed (XRootD service may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from list-directory")
-	}
+	assertLiveCommandSuccess(t, liveXRootD, err, ctx.Err(), string(output), "list-directory")
 }
 
 func TestIntegrationListDirectoryVerbose(t *testing.T) {
@@ -534,14 +534,7 @@ func TestIntegrationListDirectoryVerbose(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "list-directory", "/eos/opendata/cms", "--verbose")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: list-directory verbose failed (XRootD service may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from list-directory verbose")
-	}
+	assertLiveCommandSuccess(t, liveXRootD, err, ctx.Err(), string(output), "verbose list-directory")
 
 	outputStr := string(output)
 	if len(outputStr) < 20 {
@@ -560,14 +553,7 @@ func TestIntegrationListDirectoryWrongPath(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "list-directory", "/eos/opendata/foobar")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: list-directory wrong path failed (XRootD service may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if !contains(string(output), "does not exist") && !contains(string(output), "not found") && !contains(string(output), "failed") {
-		t.Log("Note: Expected 'does not exist' error for wrong path")
-	}
+	assertCommandErrorContains(t, err, string(output), "list-directory with a nonexistent path", "Failed to list directory", "No such file or directory")
 }
 
 func TestIntegrationListDirectoryEmpty(t *testing.T) {
@@ -581,14 +567,7 @@ func TestIntegrationListDirectoryEmpty(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "list-directory", "/eos/opendata/test/nonexistent")
 	output, err := cmd.CombinedOutput()
-	if err == nil && len(output) == 0 {
-		t.Log("Expected empty directory or error")
-		return
-	}
-
-	if len(output) == 0 {
-		t.Log("No output (expected for non-existent directory)")
-	}
+	assertCommandErrorContains(t, err, string(output), "list-directory with the nonexistent test path", "Failed to list directory", "No such file or directory")
 }
 
 func TestIntegrationHelp(t *testing.T) {
@@ -620,6 +599,15 @@ func adlerChecksum(content []byte) string {
 	return fmt.Sprintf("adler32:%08x", adler32.Checksum(content))
 }
 
+func mustReadDir(t *testing.T, path string) []os.DirEntry {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		t.Fatalf("Failed to read directory %s: %v", path, err)
+	}
+	return entries
+}
+
 func TestIntegrationDownloadFilesFromRecid(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -630,17 +618,13 @@ func TestIntegrationDownloadFilesFromRecid(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files by recid")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
 
-	if _, err := os.Stat(filepath.Join(tmpDir, "0d0714743f0204ed3c0144941e6ce248.configFile.py")); os.IsNotExist(err) {
-		t.Error("Expected file to be downloaded")
+	if _, err := os.Stat(filepath.Join(tmpDir, "0d0714743f0204ed3c0144941e6ce248.configFile.py")); err != nil {
+		t.Fatalf("Expected fixture file to be downloaded: %v", err)
 	}
 }
 
@@ -743,13 +727,7 @@ func TestIntegrationDownloadFilesFromRecidWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "0")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for invalid recid 0, but got none")
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected error message for invalid recid")
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files with recid zero", "please provide recid, doi, or title")
 }
 
 func TestIntegrationDownloadFilesFilterName(t *testing.T) {
@@ -762,16 +740,12 @@ func TestIntegrationDownloadFilesFilterName(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--filter-name", "BuildFile.xml", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with a name filter")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	found := false
 	for _, f := range files {
 		if contains(f.Name(), "BuildFile") {
@@ -794,14 +768,7 @@ func TestIntegrationDownloadFilesFilterNameWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--filter-name", "nonexistent.txt", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for non-matching filter, but got none")
-	}
-
-	outputStr := string(output)
-	if !contains(outputStr, "No files") {
-		t.Error("Expected 'No files matching filters' message")
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files with a non-matching name filter", "No files matching filters")
 }
 
 func TestIntegrationDownloadFilesFilterRange(t *testing.T) {
@@ -814,11 +781,9 @@ func TestIntegrationDownloadFilesFilterRange(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--filter-range", "0-2", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with a range filter")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) == 0 {
 		t.Error("Expected some files to be downloaded with range filter")
 	}
@@ -834,12 +799,9 @@ func TestIntegrationDownloadFilesFilterRangeInvalid(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--filter-range", "5-2", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: download failed (invalid range): %v\nOutput: %s", err, string(output))
-		return
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files with an invalid range", "Invalid range filter", "range end must be >= start")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) > 0 {
 		t.Error("Expected no files to be downloaded with invalid range")
 	}
@@ -855,11 +817,7 @@ func TestIntegrationDownloadFilesRetry(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--retry-limit", "2", "--filter-name", "*.py", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with retries")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
@@ -875,14 +833,7 @@ func TestIntegrationDownloadFilesVerbose(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--verbose", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
-	if len(outputStr) == 0 {
-		t.Error("Expected non-empty verbose output")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verbose download-files")
 }
 
 func TestIntegrationDownloadFilesNoIdentifier(t *testing.T) {
@@ -893,14 +844,7 @@ func TestIntegrationDownloadFilesNoIdentifier(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error when no identifier provided, but got none")
-	}
-
-	outputStr := string(output)
-	if !contains(outputStr, "recid") && !contains(outputStr, "doi") && !contains(outputStr, "title") {
-		t.Error("Expected error message to mention required identifier")
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files without an identifier", "please provide recid, doi, or title")
 }
 
 func TestIntegrationDownloadFilesInvalidServer(t *testing.T) {
@@ -911,14 +855,7 @@ func TestIntegrationDownloadFilesInvalidServer(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--server", "ftp://invalid.com", "--dry-run")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for invalid server, but got none")
-	}
-
-	outputStr := string(output)
-	if len(outputStr) == 0 {
-		t.Error("Expected error message for invalid server")
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files with an invalid server scheme", "Failed to get record", "unsupported protocol scheme \"ftp\"")
 }
 
 func TestIntegrationDownloadFilesCustomOutputDir(t *testing.T) {
@@ -931,11 +868,9 @@ func TestIntegrationDownloadFilesCustomOutputDir(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with a custom output directory")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) == 0 {
 		t.Error("Expected files to be downloaded to custom output directory")
 	}
@@ -951,18 +886,12 @@ func TestIntegrationVerifyFilesBasic(t *testing.T) {
 	// #nosec G204
 	downloadCmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--output-dir", tmpDir)
 	downloadOutput, downloadErr := downloadCmd.CombinedOutput()
-	if downloadErr != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", downloadErr, string(downloadOutput))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, downloadErr, nil, string(downloadOutput), "download fixture for verification")
 
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files", "--recid", testRecID, "--input-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run verify-files: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verify-files")
 	if !contains(outputStr, "Verification summary") {
 		t.Error("Expected verification summary in output")
 	}
@@ -984,18 +913,12 @@ func TestIntegrationVerifyFilesByNameFilter(t *testing.T) {
 	// #nosec G204
 	downloadCmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--output-dir", tmpDir)
 	downloadOutput, downloadErr := downloadCmd.CombinedOutput()
-	if downloadErr != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", downloadErr, string(downloadOutput))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, downloadErr, nil, string(downloadOutput), "download fixture for filtered verification")
 
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files", "--recid", testRecID, "--input-dir", tmpDir, "--filter-name", "*.py")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run verify-files with name filter: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verify-files with a name filter")
 	if !contains(outputStr, "Verification summary") {
 		t.Error("Expected verification summary in output")
 	}
@@ -1009,14 +932,7 @@ func TestIntegrationVerifyFilesNoIdentifier(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error when no identifier provided, but got none")
-	}
-
-	outputStr := string(output)
-	if !contains(outputStr, "recid") && !contains(outputStr, "doi") && !contains(outputStr, "title") {
-		t.Error("Expected error message to mention required identifier")
-	}
+	assertCommandErrorContains(t, err, string(output), "verify-files without an identifier", "please provide recid, doi, or title")
 }
 
 func TestIntegrationVerifyFilesByDOI(t *testing.T) {
@@ -1031,20 +947,12 @@ func TestIntegrationVerifyFilesByDOI(t *testing.T) {
 	// #nosec G204
 	downloadCmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--output-dir", tmpDir)
 	downloadOutput, downloadErr := downloadCmd.CombinedOutput()
-	if downloadErr != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", downloadErr, string(downloadOutput))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, downloadErr, nil, string(downloadOutput), "download DOI verification fixture")
 
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files", "--doi", "10.7483/OPENDATA.CMS.JKB8.RR42", "--input-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run verify-files by DOI: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from verify-files")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verify-files by DOI")
 }
 
 func TestIntegrationVerifyFilesByTitle(t *testing.T) {
@@ -1059,20 +967,12 @@ func TestIntegrationVerifyFilesByTitle(t *testing.T) {
 	// #nosec G204
 	downloadCmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--output-dir", tmpDir)
 	downloadOutput, downloadErr := downloadCmd.CombinedOutput()
-	if downloadErr != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", downloadErr, string(downloadOutput))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, downloadErr, nil, string(downloadOutput), "download title verification fixture")
 
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files", "--title", "Configuration file for LHE step HIG-Summer11pLHE-00114_1_cfg.py", "--input-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run verify-files by title: %v\nOutput: %s", err, string(output))
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from verify-files")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verify-files by title")
 }
 
 func TestIntegrationVerifyFilesInvalidServer(t *testing.T) {
@@ -1083,14 +983,7 @@ func TestIntegrationVerifyFilesInvalidServer(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files", "--recid", testRecID, "--server", "ftp://invalid.com")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error for invalid server, but got none")
-	}
-
-	outputStr := string(output)
-	if len(outputStr) == 0 {
-		t.Error("Expected error message for invalid server")
-	}
+	assertCommandErrorContains(t, err, string(output), "verify-files with an invalid server scheme", "Failed to get record", "unsupported protocol scheme \"ftp\"")
 }
 
 func TestIntegrationVerifyFilesCustomInputDir(t *testing.T) {
@@ -1103,9 +996,7 @@ func TestIntegrationVerifyFilesCustomInputDir(t *testing.T) {
 	// #nosec G204
 	downloadCmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--output-dir", tmpDir)
 	downloadOutput, downloadErr := downloadCmd.CombinedOutput()
-	if downloadErr != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", downloadErr, string(downloadOutput))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, downloadErr, nil, string(downloadOutput), "download custom-input verification fixture")
 
 	customDir := filepath.Join(tmpDir, "subdir")
 	if err := os.MkdirAll(customDir, 0750); err != nil {
@@ -1115,11 +1006,7 @@ func TestIntegrationVerifyFilesCustomInputDir(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "verify-files", "--recid", testRecID, "--input-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run verify-files with custom dir: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "verify-files with a custom input directory")
 	if !contains(outputStr, "Verification summary") {
 		t.Error("Expected verification summary in output")
 	}
@@ -1135,11 +1022,9 @@ func TestIntegrationDownloadFilesRegexp(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-regexp", ".*\\.py$", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with a regular-expression filter")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) == 0 {
 		t.Error("Expected some Python files to be downloaded with regex filter")
 	}
@@ -1161,11 +1046,9 @@ func TestIntegrationDownloadFilesRegexpMultiple(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-regexp", "(.*\\.py$|.*\\.txt$)", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with multiple regular-expression filters")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) == 0 {
 		t.Error("Expected some files to be downloaded with multiple regex filter")
 	}
@@ -1181,12 +1064,9 @@ func TestIntegrationDownloadFilesRegexpWrong(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-regexp", "nonexistentfile.*", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: download failed: %v\nOutput: %s", err, string(output))
-		return
-	}
+	assertCommandErrorContains(t, err, string(output), "download-files with an unmatched regular expression", "No files matching filters")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) > 0 {
 		t.Error("Expected no files to be downloaded with non-matching regex filter")
 	}
@@ -1202,11 +1082,9 @@ func TestIntegrationDownloadFilesMultipleNameFilters(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py,*.txt", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with multiple name filters")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) == 0 {
 		t.Error("Expected some files to be downloaded with multiple name filters")
 	}
@@ -1229,11 +1107,9 @@ func TestIntegrationDownloadFilesMultipleRanges(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--filter-range", "0-1,3-4", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with multiple ranges")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 	if len(files) < 2 {
 		t.Error("Expected at least 2 files to be downloaded with multiple ranges (0-1,3-4)")
 	}
@@ -1249,11 +1125,9 @@ func TestIntegrationDownloadFilesRegexpAndRange(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-regexp", ".*\\.py$", "--filter-range", "0-2", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with regular-expression and range filters")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 
 	for _, f := range files {
 		if !contains(f.Name(), ".py") {
@@ -1272,11 +1146,9 @@ func TestIntegrationDownloadFilesRegexpAndMultipleRanges(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", "5500", "--filter-regexp", ".*\\.xml$", "--filter-range", "0-1,3-4", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" download failed: %v\nOutput: %s", err, string(output))
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with regular-expression and multiple-range filters")
 
-	files, _ := os.ReadDir(tmpDir)
+	files := mustReadDir(t, tmpDir)
 
 	for _, f := range files {
 		if !contains(f.Name(), ".xml") {
@@ -1293,14 +1165,7 @@ func TestIntegrationListDirectoryRecursive(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "list-directory", "/eos/opendata/cms/software/HiggsExample20112012", "--recursive")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" list-directory recursive failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
-	if len(outputStr) == 0 {
-		t.Error("Expected non-empty output from recursive directory listing")
-	}
+	outputStr := assertLiveCommandSuccess(t, liveXRootD, err, nil, string(output), "recursive list-directory")
 
 	entries := strings.Split(outputStr, "\n")
 	if len(entries) < 10 {
@@ -1313,25 +1178,12 @@ func TestIntegrationListDirectoryTimeout(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	// Use a very short timeout that should cause context cancellation
+	// Exercise a bounded XRootD listing. A recognized transport outage may skip;
+	// otherwise the command must complete successfully with nonempty output.
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "list-directory", "/eos/opendata/cms/software/HiggsExample20112012", "--timeout", "5")
 	output, err := cmd.CombinedOutput()
-	// The test passes if it completes (either successfully or with timeout error)
-	// We just want to ensure that timeout flag doesn't break the command
-	if err != nil && len(output) == 0 {
-		t.Logf("Note: Command failed with timeout (expected behavior): %v", err)
-	}
-
-	// As long as we got output or a clear error, test passes
-	if len(output) > 0 {
-		t.Logf("Got %d bytes of output before potential timeout", len(output))
-	}
-
-	// As long as we got output or a clear error, the test passes
-	if len(output) > 0 {
-		t.Logf("Got %d bytes of output before potential timeout", len(output))
-	}
+	assertLiveCommandSuccess(t, liveXRootD, err, nil, string(output), "list-directory with timeout flag")
 }
 
 func TestIntegrationDownloadFilesWithVerify(t *testing.T) {
@@ -1344,11 +1196,7 @@ func TestIntegrationDownloadFilesWithVerify(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--verify", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run download-files with verify: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with verification")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
@@ -1368,11 +1216,7 @@ func TestIntegrationDownloadFilesWithDownloadEngine(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--download-engine", "http", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run download-files with download-engine: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with the HTTP engine")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
@@ -1388,11 +1232,7 @@ func TestIntegrationDownloadFilesWithRetrySleep(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--retry-sleep", "2", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to run download-files with retry-sleep: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files with retry sleep")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
@@ -1408,12 +1248,7 @@ func TestIntegrationDownloadFilesWithXRootD(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--download-engine", "xrootd", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(" XRootD download failed (XRootD server may be unavailable): %v\nOutput: %s", err, string(output))
-		t.Skip("Skipping XRootD test - server unavailable")
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveXRootD, err, nil, string(output), "XRootD download")
 	if !contains(outputStr, "Success") {
 		t.Error("Expected 'Success!' message in output")
 	}
@@ -1437,18 +1272,7 @@ func TestIntegrationDownloadFilesXRootDError(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testRecID, "--filter-name", "*.py", "--download-engine", "xrootd", "--server", "http://invalid.cern.ch", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Log("Note: Command completed (XRootD error handling worked)")
-	}
-
-	outputStr := string(output)
-	if len(outputStr) > 0 {
-		t.Logf("Output: %s", outputStr)
-	}
-
-	if err != nil && len(outputStr) > 0 {
-		t.Log("Got expected error from invalid XRootD server")
-	}
+	assertCommandErrorContains(t, err, string(output), "XRootD download with an invalid metadata server", "Failed to get record")
 }
 
 func TestIntegrationSearchBasic(t *testing.T) {
@@ -1462,14 +1286,7 @@ func TestIntegrationSearchBasic(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--query-pattern", "Higgs", "--size", "3")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: search failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from search")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "basic search")
 }
 
 func TestIntegrationSearchWithFacets(t *testing.T) {
@@ -1483,14 +1300,7 @@ func TestIntegrationSearchWithFacets(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--query-pattern", "muon", "--query-facet", "experiment=CMS", "--size", "5")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: search with facets failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from search with facets")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "search with facets")
 }
 
 func TestIntegrationSearchWithURL(t *testing.T) {
@@ -1504,14 +1314,7 @@ func TestIntegrationSearchWithURL(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--query", "q=test&f=experiment:CMS", "--size", "3")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: search with URL query failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from search with URL query")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "search with URL query")
 }
 
 func TestIntegrationSearchOutputValue(t *testing.T) {
@@ -1525,14 +1328,7 @@ func TestIntegrationSearchOutputValue(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--query-pattern", "Higgs", "--output-value", "title", "--size", "3")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: search with output-value failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	if len(output) == 0 {
-		t.Error("Expected non-empty output from search with output-value")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "search with output value")
 }
 
 func TestIntegrationSearchFormatJSON(t *testing.T) {
@@ -1546,14 +1342,13 @@ func TestIntegrationSearchFormatJSON(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--query-pattern", "Higgs", "--output-value", "title", "--format", "json", "--size", "3")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: search with JSON format failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "JSON search")
+	var titles []string
+	if err := json.Unmarshal([]byte(outputStr), &titles); err != nil {
+		t.Fatalf("JSON search returned malformed output: %v\nOutput: %s", err, outputStr)
 	}
-
-	outputStr := string(output)
-	if len(outputStr) > 0 && !strings.Contains(outputStr, "[") {
-		t.Error("Expected JSON array output")
+	if len(titles) == 0 {
+		t.Fatal("JSON search returned an empty result fixture")
 	}
 }
 
@@ -1568,14 +1363,9 @@ func TestIntegrationSearchNoResults(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--query-pattern", "xyznonexistent12345")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: search failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "search with no results")
 	if !contains(outputStr, "No records found") {
-		t.Logf("Output: %s", outputStr)
+		t.Fatalf("Expected the no-results product diagnostic\nOutput: %s", outputStr)
 	}
 }
 
@@ -1614,14 +1404,7 @@ func TestIntegrationSearchFilterWithoutOutputValue(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "search", "--query-pattern", "test", "--filter", "foo=bar")
 	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("Expected error when using --filter without --output-value")
-	}
-
-	outputStr := string(output)
-	if !contains(outputStr, "--filter") || !contains(outputStr, "--output-value") {
-		t.Error("Expected message about --filter requiring --output-value")
-	}
+	assertCommandErrorContains(t, err, string(output), "search filter without output value", "--filter can only be used with --output-value")
 }
 
 func TestIntegrationSearchListFacets(t *testing.T) {
@@ -1635,12 +1418,7 @@ func TestIntegrationSearchListFacets(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--list-facets")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: --list-facets failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "search --list-facets")
 
 	// Check that we got some facet output
 	if !contains(outputStr, "Available facets") {
@@ -1664,25 +1442,12 @@ func TestIntegrationSearchListFacetsWithServer(t *testing.T) {
 	// #nosec G204
 	cmd := exec.CommandContext(ctx, getBinaryPath(), "search", "--list-facets", "--server", "https://opendata.cern.ch")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: --list-facets with --server failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
-
-	outputStr := string(output)
-	if len(outputStr) == 0 {
-		t.Error("Expected non-empty output from --list-facets")
-	}
+	assertLiveCommandSuccess(t, liveCERNHTTP, err, ctx.Err(), string(output), "search --list-facets with explicit server")
 }
 
 func TestIntegrationUpdateCheck(t *testing.T) {
-	// Skip on macOS due to intermittent GitHub API 403 errors on GitHub Actions macOS runners.
-	// The test runs successfully on Linux, so we only skip on darwin/macOS.
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping update check test on macOS due to intermittent GitHub API failures")
-	}
-
-	output := assertCommandSuccess(t, "update", "--check")
+	output, err := runIntegrationCommand(t, "update", "--check")
+	output = assertLiveCommandSuccess(t, liveGitHub, err, nil, output, "update --check")
 	if !strings.Contains(output, "Current version:") {
 		t.Error("Expected 'Current version:' in output")
 	}
@@ -1720,11 +1485,7 @@ func TestIntegrationGetFileLocationsAvailabilityOnline(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testUnavailableRecID, "--file-availability", "online")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("get-file-locations failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations for online files")
 	lines := strings.Split(strings.TrimSpace(outputStr), "\n")
 	// Should match exactly 1 line (record 8886 has 1 online file)
 	count := 0
@@ -1746,21 +1507,17 @@ func TestIntegrationGetFileLocationsAvailabilityAll(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testUnavailableRecID, "--file-availability", "all")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("get-file-locations failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations for all files")
 	lines := strings.Split(strings.TrimSpace(outputStr), "\n")
-	// Should match 2997 files
+	// Record 8886 currently exposes exactly 5,089 files across online and tape storage.
 	count := 0
 	for _, line := range lines {
 		if strings.TrimSpace(line) != "" && !strings.HasPrefix(line, "==>") {
 			count++
 		}
 	}
-	if count < 100 {
-		t.Errorf("Expected many files (>100), got %d. Output:\n%s", count, outputStr)
+	if count != 5089 {
+		t.Errorf("Expected exactly 5089 files, got %d. Output:\n%s", count, outputStr)
 	}
 }
 
@@ -1773,11 +1530,7 @@ func TestIntegrationGetFileLocationsAvailabilityWarning(t *testing.T) {
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testUnavailableRecID)
 	// We expect success (err == nil) but warning in stderr
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("get-file-locations failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations availability warning")
 	// Note: CombinedOutput captures both stdout and stderr
 	if !contains(outputStr, "WARNING: Some files in the list are not online") {
 		t.Error("Expected warning about offline files not found in output")
@@ -1794,11 +1547,7 @@ func TestIntegrationDownloadFilesAvailabilityOnline(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testUnavailableRecID, "--file-availability", "online", "--dry-run", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("download-files failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files for online files")
 	if !contains(outputStr, "Files downloaded: 1 /") {
 		t.Error("Expected 'Files downloaded: 1' in summary")
 	}
@@ -1817,11 +1566,7 @@ func TestIntegrationDownloadFilesAvailabilityWarning(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "download-files", "--recid", testUnavailableRecID, "--dry-run", "--output-dir", tmpDir)
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("download-files failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "download-files availability warning")
 	if !contains(outputStr, "WARNING: Some files are stored on tape and will be skipped") {
 		t.Error("Expected warning about skipped files")
 	}
@@ -1838,14 +1583,11 @@ func TestIntegrationGetFileLocationsJSON(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "get-file-locations", "--recid", testRecID, "--format", "json")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: get-file-locations with JSON format failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
+	outputStr := assertLiveCommandSuccess(t, liveCERNHTTP, err, nil, string(output), "get-file-locations JSON")
 
 	var files []map[string]interface{}
-	if err := json.Unmarshal([]byte(output), &files); err != nil {
-		t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, string(output))
+	if err := json.Unmarshal([]byte(outputStr), &files); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, outputStr)
 	}
 
 	if len(files) == 0 {
@@ -1858,7 +1600,6 @@ func TestIntegrationGetFileLocationsJSON(t *testing.T) {
 		}
 	}
 
-	t.Logf("Successfully got %d files in JSON format", len(files))
 }
 
 func TestIntegrationListDirectoryJSON(t *testing.T) {
@@ -1869,14 +1610,11 @@ func TestIntegrationListDirectoryJSON(t *testing.T) {
 	// #nosec G204
 	cmd := exec.Command(getBinaryPath(), "list-directory", "/eos/opendata/cms/software/HiggsExample20112012", "--format", "json")
 	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Warning: list-directory with JSON format failed (network may be unavailable): %v\nOutput: %s", err, string(output))
-		return
-	}
+	outputStr := assertLiveCommandSuccess(t, liveXRootD, err, nil, string(output), "list-directory JSON")
 
 	var entries []map[string]interface{}
-	if err := json.Unmarshal(output, &entries); err != nil {
-		t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, string(output))
+	if err := json.Unmarshal([]byte(outputStr), &entries); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, outputStr)
 	}
 
 	if len(entries) == 0 {
@@ -1892,5 +1630,4 @@ func TestIntegrationListDirectoryJSON(t *testing.T) {
 		}
 	}
 
-	t.Logf("Successfully got %d entries in JSON format", len(entries))
 }


### PR DESCRIPTION
## Summary
- classify and skip only recognized, service-scoped environmental failures
- require named product diagnostics for intentional error paths
- remove warning-and-return, log-and-pass, and unconditional macOS skip behavior
- require valid nonempty JSON, expected files, and exact live fixture baselines
- fail directory-read errors instead of treating them as empty results

## Local validation
- focused classifier and diagnostic tests
- `make test-integration`
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `make build-all`
- `PATH=/Users/clange/go/bin:$PATH prek run --all-files`
- `git diff --check`