### PR TITLE
fix: include maintenance changes in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,61 @@
   "bump-minor-pre-major": true,
   "initial-version": "0.1.0",
   "label": "autorelease: pending",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "feature",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "test",
+      "section": "Tests"
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ],
   "packages": {
     ".": {
       "package-name": "cernopendata-client"


### PR DESCRIPTION
## Summary
- preserve Release Please’s standard conventional-commit section mappings
- include non-breaking `refactor` commits in v0.10.0 notes
- include test hardening commits in v0.10.0 notes
- keep chores, CI, build, style, and standalone docs hidden as before

## Validation
- `jq empty release-please-config.json`
- `PATH=/Users/clange/go/bin:$PATH prek run --all-files`
- `git diff --check`
- verified against the upstream Release Please manifest schema